### PR TITLE
work in progress: add tooltips to editor

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
     "react-redux": "^5.0.6",
     "react-scripts": "1.0.17",
     "react-split-pane": "^0.1.74",
+    "react-tooltip": "^3.5.1",
     "react-treebeard": "^2.1.0",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",

--- a/app/src/activities.js
+++ b/app/src/activities.js
@@ -6,6 +6,8 @@ import { SIDEBAR_COMPONENT, REPL_COMPONENT } from './constants';
 const activities = [
   {
     selector: 'editor',
+    tooltipMessage: 'toggle file viewer',
+    tooltipPosition: 'right',
     icon: ICONS['file-text2'],
     toggle: SIDEBAR_COMPONENT,
     view: BoundEditActivity,
@@ -13,6 +15,8 @@ const activities = [
   },
   {
     selector: 'editor',
+    tooltipMessage: 'toggle repl',
+    tooltipPosition: 'right',
     icon: ICONS.terminal,
     toggle: REPL_COMPONENT,
     view: BoundEditActivity,
@@ -20,10 +24,12 @@ const activities = [
   },
   {
     selector: 'configure',
+    tooltipMessage: 'configure',
+    tooltipPosition: 'right',
     icon: ICONS.cog,
     view: ConfigureActivity,
     position: 'lower',
-  },
+  }
 ];
 
 export default activities;

--- a/app/src/activity-bar.js
+++ b/app/src/activity-bar.js
@@ -13,6 +13,8 @@ class ActivityBar extends Component {
         <IconButton
           key={activity.selector + activity.toggle}
           action={() => this.props.buttonAction(activity)}
+          tooltipMessage={activity.tooltipMessage}
+          tooltipPosition={activity.tooltipPosition}
           icon={activity.icon}
           color="#979797" // FIXME: this should be styled
           size="24"

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import BoundWorkspace from './bound-workspace';
 import activities from './activities';
 import './app.css';
+import './tool-tip.css';
 
 class App extends Component {
   constructor(props) {

--- a/app/src/edit-activity.js
+++ b/app/src/edit-activity.js
@@ -13,11 +13,15 @@ import './edit-activity.css';
 const tools = [
     {
         name: "save",
+        tooltipMessage: "save script",
+        tooltipPosition: "left",
         icon: ICONS["floppy-disk"],
         disabled: false,
     },
     {
         name: "play",
+        tooltipMessage: "run script",
+        tooltipPosition: "left",
         icon: ICONS["play3"],
         disabled: false,
     },
@@ -27,6 +31,8 @@ const EditTools = (props) => {
     const items = props.tools.map(tool => {
         return (
             <IconButton
+                tooltipMessage={tool.tooltipMessage}
+                tooltipPosition={tool.tooltipPosition}
                 key={tool.name}
                 action={() => props.buttonAction(tool.name)}
                 icon={tool.icon}

--- a/app/src/explorer.js
+++ b/app/src/explorer.js
@@ -45,6 +45,8 @@ const SectionHeader = (props) => {
         return (
             <IconButton
                 key={tool.name}
+                tooltipMessage={tool.tooltipMessage}
+                tooltipPosition={tool.tooltipPosition}
                 action={() => props.buttonAction(tool.name)}
                 icon={tool.icon}
                 size="12"
@@ -246,22 +248,27 @@ const scriptTools = [
     {
         name: "add",
         icon: ICONS["plus"],
+        tooltipMessage: "new script"
     },
     {
         name: "remove",
         icon: ICONS["minus"],
+        tooltipMessage: "delete script"
     },
     {
         name: "duplicate",
         icon: ICONS["copy"],
+        tooltipMessage: "duplicate script"
     },
     {
         name: "new-folder",
         icon: ICONS["folder-plus"],
+        tooltipMessage: "new folder"
     },
     {
         name: "rename",
         icon: ICONS["pencil"],
+        tooltipMessage: "rename file/folder"
     },
 ]
 
@@ -269,18 +276,47 @@ const audioTools = [
     {
         name: "remove",
         icon: ICONS["minus"],
+        tooltipMessage: "delete audio file"
     },
     {
         name: "new-folder",
         icon: ICONS["folder-plus"],
+        tooltipMessage: "new folder"
     },
     {
         name: "rename",
         icon: ICONS["pencil"],
+        tooltipMessage: "rename file/folder"
     },
 ]
 
-const dataTools = scriptTools;
+const dataTools = [
+    {
+        name: "add",
+        icon: ICONS["plus"],
+        tooltipMessage: "new data file"
+    },
+    {
+        name: "remove",
+        icon: ICONS["minus"],
+        tooltipMessage: "delete data file"
+    },
+    {
+        name: "duplicate",
+        icon: ICONS["copy"],
+        tooltipMessage: "duplicate data file"
+    },
+    {
+        name: "new-folder",
+        icon: ICONS["folder-plus"],
+        tooltipMessage: "new folder"
+    },
+    {
+        name: "rename",
+        icon: ICONS["pencil"],
+        tooltipMessage: "rename file/folder"
+    },
+]
 
 
 class Explorer extends Component {

--- a/app/src/icon-button.css
+++ b/app/src/icon-button.css
@@ -7,9 +7,3 @@
     overflow: hidden;
     outline: none;
 }
-
-/*
-.icon-button > .icon {
-    padding: 10px;
-}
-*/

--- a/app/src/icon-button.js
+++ b/app/src/icon-button.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Icon from './icon';
+import ReactTooltip from 'react-tooltip';
 import './icon-button.css';
 
 // TODO:
@@ -23,14 +24,30 @@ class IconButton extends Component {
     render() {
         let style = { padding: this.props.padding || 6 };
         let color = this.getColor();
+        let tooltipPosition = this.props.tooltipPosition || "bottom";
+        
+        function guid() {
+            function s4() {
+              return Math.floor((1 + Math.random()) * 0x10000)
+                .toString(16)
+                .substring(1);
+            }
+            return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
+        }
+        
+        let uniqueId = guid();
 
         return (
             <button
                 className="icon-button"
                 onClick={this.handleClick}
+                data-tip={this.props.tooltipMessage}
+                data-place={this.props.tooltipMessage && tooltipPosition}
+                data-for={this.props.tooltipMessage && uniqueId}
                 style={style}
             >
                 <Icon icon={this.props.icon} size={this.props.size} color={color}/>
+                {this.props.tooltipMessage && <ReactTooltip id={uniqueId} effect="solid" delayShow={1000} delayHide={500} className="customTooltip"></ReactTooltip>}
             </button>
         );
     }

--- a/app/src/modal-content.js
+++ b/app/src/modal-content.js
@@ -17,6 +17,8 @@ const ModalContent = props => (
       <IconButton
         key="cancel"
         action={() => props.buttonAction('cancel')}
+        tooltipMessage='cancel'
+        tooltipPosition='top'
         icon={ICONS.cross}
         color="#979797" // FIXME:
         size="24"
@@ -24,6 +26,8 @@ const ModalContent = props => (
       <IconButton
         key="ok"
         action={() => props.buttonAction('ok')}
+        tooltipMessage='ok'
+        tooltipPosition='top'
         icon={ICONS.check}
         color="#979797" // FIXME:
         size="30"

--- a/app/src/repl-activity.js
+++ b/app/src/repl-activity.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import ReactTooltip from 'react-tooltip';
 import cx from 'classname';
 import Repl from './repl';
 import ToolBar from './tool-bar';
@@ -10,6 +11,8 @@ import './repl-activity.css';
 const tools = [
     {
         name: "clear",
+        tooltipMessage: "clear",
+        tooltipPosition: "left",
         icon: ICONS['forbidden'], // FIXME: temp
     }
 ];
@@ -20,6 +23,8 @@ const ReplTools = (props) => {
         return (
             <IconButton
                 key={tool.name}
+                tooltipMessage={tool.tooltipMessage}
+                tooltipPosition={tool.tooltipPosition}
                 action={() => props.buttonAction(tool.name)}
                 icon={tool.icon}
                 color="#979797"       // FIXME:
@@ -48,6 +53,8 @@ const ReplConnect = (props) => {
                 <span className="component">{props.activeRepl}</span>
                 <IconButton
                     action={() => props.connectAction(props.activeRepl)}
+                    tooltipMessage="refresh connection"
+                    tooltipPosition="top"
                     icon={ICONS['loop2']}
                     color="#979797"       // FIXME:
                     size="24"           // FIXME:
@@ -59,14 +66,19 @@ const ReplConnect = (props) => {
 
 const ReplSwitcherTab = (props) => {
     let className = cx("repl-switcher-tab", {"noselect": true}, {"repl-active-tab": props.isActive});
+    let tooltipMessage = `show ${props.name} repl`; 
     return (
-        <button 
-            className={className}
-            key={props.name}
-            onClick={props.onClick}
-        >
-            {props.name}
-        </button>
+        <div>
+            <button 
+                className={className}
+                key={props.name}
+                onClick={props.onClick}
+                data-tip={tooltipMessage}
+                data-for={props.name}>
+                {props.name}
+            </button>
+            <ReactTooltip id={props.name} effect="solid" className="customTooltip" delayShow={1000} delayHide={500} place="top"></ReactTooltip>
+        </div>
     );
 }
 

--- a/app/src/tool-tip.css
+++ b/app/src/tool-tip.css
@@ -1,0 +1,18 @@
+.customTooltip {
+		font-size: 11px !important;
+		border-radius: 0 !important;
+		padding: 6px !important;
+		transition:
+			opacity .3s,
+			visibility .3s .2s;
+}
+
+.customTooltip.place-left,
+.customTooltip.place-right {
+		margin-left: 0 !important;
+		margin-right: 0 !important;
+}
+
+.customTooltip.show {
+  transition: opacity .3s;
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1355,6 +1355,10 @@ classname@^0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/classname/-/classname-0.0.0.tgz#43d171b484e354c7a293a5b78004df6852db20d6"
 
+classnames@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
 clean-css@4.1.x:
   version "4.1.9"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.9.tgz#35cee8ae7687a49b98034f70de00c4edd3826301"
@@ -5509,6 +5513,13 @@ react-style-proptype@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-style-proptype/-/react-style-proptype-3.1.0.tgz#c8912fc13460f5b0c1ec1114c729d535b52b8073"
   dependencies:
     prop-types "^15.5.4"
+
+react-tooltip@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.5.1.tgz#3ef4da70348a0e52c3caa82e626a23d89300f62e"
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
 
 react-transition-group@^1.1.2:
   version "1.2.1"


### PR DESCRIPTION
link #20 

This implements tooltips within the ui using the [react-tooltip](https://github.com/wwayne/react-tooltip) lib.

Some examples:

<img width="273" alt="screen shot 2018-05-06 at 6 51 17 pm" src="https://user-images.githubusercontent.com/1342624/39678663-8d801e30-515e-11e8-9d74-b07925483c7d.png">
<img width="198" alt="screen shot 2018-05-06 at 6 51 25 pm" src="https://user-images.githubusercontent.com/1342624/39678664-8d8bf5f2-515e-11e8-8662-9b34e9ea0181.png">
<img width="373" alt="screen shot 2018-05-06 at 6 51 30 pm" src="https://user-images.githubusercontent.com/1342624/39678665-8da3dc26-515e-11e8-9ecd-cfb0a6bd96c6.png">
<img width="136" alt="screen shot 2018-05-06 at 6 51 35 pm" src="https://user-images.githubusercontent.com/1342624/39678666-8dafbaf0-515e-11e8-9dcd-976a3a3a981c.png">
<img width="151" alt="screen shot 2018-05-06 at 6 51 42 pm" src="https://user-images.githubusercontent.com/1342624/39678667-8dbcb34a-515e-11e8-8ed4-c120fd894b9f.png">
