### PR TITLE
Initial CI pre-commit validation script.

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Fast fail.
+set -e
+
+# Check Go formatting.
+UNFORMATTED_FILES="$(gofmt -l *.go)"
+if [ -n "$UNFORMATTED_FILES" ]; then
+	echo "Failed gofmt check: run \`gofmt -w $UNFORMATTED_FILES\`"
+	exit 1
+fi
+
+# Lint JS.
+(cd app && ./node_modules/.bin/eslint src/)


### PR DESCRIPTION
First steps to scripting validation for continuous integration.  Assuming we go with travis, this script will get invoked from `.travis.yml` with a script call like this:

    script: ./tool/travis.sh

(Note that this script can also be run locally as a kind of pre-submit check.)

See #37. 

/cc @ngwese @jlmitch5 