### PR TITLE
keybindings for play, save, toggle sidebar

### DIFF
--- a/app/src/edit-activity.js
+++ b/app/src/edit-activity.js
@@ -226,6 +226,8 @@ class EditActivity extends Component {
                     ref={(component) => {this.editor = component;}}
                     { ...this.editorSize() }
                     bufferName={activeBuffer}
+                    toolInvoke={this.handleToolInvoke}
+                    sidebarToggle={this.props.sidebarToggle}
                     value={code}
                     bufferChange={this.props.bufferChange}
                 />

--- a/app/src/editor.js
+++ b/app/src/editor.js
@@ -118,6 +118,24 @@ class Editor extends Component {
                 value={this.props.value}
                 onLoad={this.onLoad}
                 onChange={this.onChange}
+                showPrintMargin={false}
+                commands={[
+                  {  
+                    name: 'save',
+                    bindKey: { win: "Ctrl-S", mac: "Command-S" },
+                    exec: () => this.props.toolInvoke('save'),
+                  },
+                  {
+                    name: 'play',
+                    bindKey: { win: "Ctrl-P", mac: "Command-P" },
+                    exec: () => this.props.toolInvoke('play'),
+                  },
+                  {
+                    name: 'toggle sidebar',
+                    bindKey: { win: "Ctrl-B", mac: "Command-B" },
+                    exec: () => this.props.sidebarToggle(),
+                  },                
+                ]}
                 editorProps={{
                     $blockScrolling: Infinity,
                     $newLineMode: "unix",


### PR DESCRIPTION
Adds keybindings (#26) for:

* ⌘S - save
* ⌘P - play
* ⌘B - toggle sidebar

_(Also cleans up print margin suppression.)_

/cc @ngwese 