### PR TITLE
de-lint app source

### DIFF
--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -1,9 +1,43 @@
 {
     "extends": "airbnb",
+    "parser": "babel-eslint",
     "rules": {
-        "react/jsx-filename-extension": [1, {"extensions": [".js"]}]
+        "react/jsx-filename-extension": [1, {"extensions": [".js"]}],
+        //TODO: audit (maiden/issues/55)
+        "class-methods-use-this": "off",
+        "no-unused-vars": ["error", {"args": "after-used", "argsIgnorePattern": "^_"}],
+        "no-case-declarations": "off",
+        "no-console": "off",
+        "import/extensions": "off",
+        "import/no-named-as-default": "off",
+        "import/no-named-as-default-member": "off",
+        "import/no-extraneous-dependencies": "off",
+        "import/no-unresolved": "off",
+        "import/prefer-default-export": "off",
+        "jsx-a11y/no-autofocus": "off",
+        "no-return-assign": "off",
+        "no-shadow": "off",
+        "no-underscore-dangle": "off",
+        "prefer-destructuring": "off",
+        "react/no-array-index-key": "off",
+        "react/no-multi-comp": "off",
+        "react/no-string-refs": "off",
+        "react/no-unused-state": "off",
+        "react/no-unescaped-entities": "off",
+        "react/prefer-stateless-function": "off",
+        "react/prop-types": "off",
+        "react/sort-comp": "off"
     },
     "globals": {
-        "navigator": true
+        "Blob": true,
+        "document": true,
+        "expect": true,
+        "fetch": true,
+        "FormData": true,
+        "it": true,
+        "navigator": true,
+        "WebSocket": true,
+        "window": true,
+        "xit": true
     }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "classname": "^0.0.0",
     "immutable": "^3.8.2",
+    "npm": "^6.0.0",
     "parse-filepath": "^1.0.2",
     "react": "^16.2.0",
     "react-ace": "^5.9.0",
@@ -29,8 +30,10 @@
   },
   "proxy": "http://localhost:5000",
   "devDependencies": {
+    "babel-eslint": "^7.2.3",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^16.1.0",
+    "eslint-plugin-babel": "^5.1.0",
     "eslint-plugin-import": "^2.11.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.7.0",

--- a/app/src/activities.js
+++ b/app/src/activities.js
@@ -30,7 +30,7 @@ const activities = [
     icon: ICONS.cog,
     view: ConfigureActivity,
     position: 'lower',
-  }
+  },
 ];
 
 export default activities;

--- a/app/src/api.js
+++ b/app/src/api.js
@@ -57,7 +57,8 @@ class API {
     const origin = document.location.hostname;
     fetch('repl-endpoints.json').then((response) => {
       response.json().then((data) => {
-        // this is ugly; if hostname is missing from the ws urls for the repls insert the hostname of this document
+        // this is ugly; if hostname is missing from the ws urls for the repls insert the hostname
+        // of this document
         const config = new Map();
         const template = new Map(Object.entries(data));
         template.forEach((value, key) => {
@@ -72,20 +73,23 @@ class API {
     });
   }
 
-  resourceForScript(name, path) {
+  resourceForScript(name, _path) {
     // TODO: would be good to clean up and normalize urls
     // TODO: implement path (subdir) support
     return apiPath(name);
   }
 
   fileFromResource(resource) {
-    // MAINT: this totally breaks the encapsulation of script resources and returns what matron would see as the script path
+    // MAINT: this totally breaks the encapsulation of script resources and returns what matron
+    // would see as the script path
     const prefix = apiPath('scripts/');
     return resource.split(prefix)[1];
   }
 
   categoryFromResource(resource) {
-    // MAINT: another case of broken encapsulation, explorer sections/category tool actions need to ensure the only operate on stuff in their section but the global selection (activeBuffer) is just a URL. here we do evil stuff like extract information out of the URL
+    // MAINT: another case of broken encapsulation, explorer sections/category tool actions need to
+    // ensure the only operate on stuff in their section but the global selection (activeBuffer) is
+    // just a URL. here we do evil stuff like extract information out of the URL
     const tail = resource.split(API_ROOT)[1];
     return tail.split('/')[1];
   }

--- a/app/src/bound-repl-activity.js
+++ b/app/src/bound-repl-activity.js
@@ -20,7 +20,8 @@ const isConnected = state => (component) => {
 };
 
 const mapStateToProps = (state) => {
-  // TODO: pull out the buffer and history for the active repl to avoid re-renders if output to no-active repl is received.
+  // TODO: pull out the buffer and history for the active repl to avoid re-renders if output to
+  // no-active repl is received.
   const {
     activeRepl, endpoints, buffers, history,
   } = state.repl;

--- a/app/src/edit-activity.js
+++ b/app/src/edit-activity.js
@@ -7,292 +7,292 @@ import IconButton from './icon-button';
 import { ICONS } from './svg-icons';
 import OS from './utils';
 
-import ReplActivity from './bound-repl-activity'
+import ReplActivity from './bound-repl-activity';
 
 import './edit-activity.css';
 
 const tools = [
-    {
-        name: "save",
-        tooltipMessage: `save script (${OS.metaKey()}S)`,
-        tooltipPosition: "left",
-        icon: ICONS["floppy-disk"],
-        disabled: false,
-    },
-    {
-        name: "play",
-        tooltipMessage: `run script (${OS.metaKey()}P)`,
-        tooltipPosition: "left",
-        icon: ICONS["play3"],
-        disabled: false,
-    },
+  {
+    name: 'save',
+    tooltipMessage: `save script (${OS.metaKey()}S)`,
+    tooltipPosition: 'left',
+    icon: ICONS['floppy-disk'],
+    disabled: false,
+  },
+  {
+    name: 'play',
+    tooltipMessage: `run script (${OS.metaKey()}P)`,
+    tooltipPosition: 'left',
+    icon: ICONS.play3,
+    disabled: false,
+  },
 ];
 
 const EditTools = (props) => {
-    const items = props.tools.map(tool => {
-        return (
-            <IconButton
-                tooltipMessage={tool.tooltipMessage}
-                tooltipPosition={tool.tooltipPosition}
-                key={tool.name}
-                action={() => props.buttonAction(tool.name)}
-                icon={tool.icon}
-                color="#979797"       // FIXME:
-                disabledColor="rgb(175, 175, 175)"
-                size="24"           // FIXME:
-                disabled={tool.disabled}
-            />
-        );
-    });
+  const items = props.tools.map(tool => (
+    <IconButton
+      tooltipMessage={tool.tooltipMessage}
+      tooltipPosition={tool.tooltipPosition}
+      key={tool.name}
+      action={() => props.buttonAction(tool.name)}
+      icon={tool.icon}
+      color="#979797" // FIXME:
+      disabledColor="rgb(175, 175, 175)"
+      size="24" // FIXME:
+      disabled={tool.disabled}
+    />
+  ));
 
-    const style = { width: props.width, height: props.height };
-    return (
-        <ToolBar style={style}>
-            {items}
-        </ToolBar>
-    );
+  const style = { width: props.width, height: props.height };
+  return (
+    <ToolBar style={style}>
+      {items}
+    </ToolBar>
+  );
 };
 
 class EditActivity extends Component {
-    constructor(props) {
-        super(props)
-        this.state = {
-            toolbarWidth: 50,
-            sidebarWidth: props.ui.sidebarWidth,
-            editorHeight: props.height - props.ui.replHeight,
-        }
+  constructor(props) {
+    super(props);
+    this.state = {
+      toolbarWidth: 50,
+      sidebarWidth: props.ui.sidebarWidth,
+      editorHeight: props.height - props.ui.replHeight,
+    };
+  }
+
+  componentWillReceiveProps(newProps) {
+    // if the active buffer is dirty grab it out of the child prior to a potential re-render so that
+    // the current buffer state isn't lost
+    const { activeBuffer, buffers } = this.props;
+    const newActiveBuffer = newProps.activeBuffer;
+    if ((activeBuffer !== newActiveBuffer) && buffers.has(activeBuffer)) {
+      if (this.editor) {
+        this.props.bufferChange(activeBuffer, this.editor.getValue());
+      }
     }
 
-    componentWillReceiveProps(newProps) {
-        // if the active buffer is dirty grab it out of the child prior to a potential re-render so that the current buffer state isn't lost
-        let { activeBuffer, buffers } = this.props;
-        let newActiveBuffer = newProps.activeBuffer;
-        if ((activeBuffer !== newActiveBuffer) && buffers.has(activeBuffer)) {
-            if (this.editor) {
-                this.props.bufferChange(activeBuffer, this.editor.getValue());
-            }
-        }
-
-        let newBuffers = newProps.buffers;
-        if (newActiveBuffer && !newBuffers.has(newActiveBuffer)) {
-            // active buffer isn't (yet) loaded, trigger read
-            this.props.bufferRead(this.props.api, newActiveBuffer);
-        }
+    const newBuffers = newProps.buffers;
+    if (newActiveBuffer && !newBuffers.has(newActiveBuffer)) {
+      // active buffer isn't (yet) loaded, trigger read
+      this.props.bufferRead(this.props.api, newActiveBuffer);
     }
+  }
 
-    sidebarSplitSizing() {
-        return {
-            size: this.props.ui.sidebarHidden ? 1 : this.state.sidebarWidth,
-            minSize: this.props.ui.sidebarMinWidth,
-            defaultSize: this.props.ui.sidebarWidth,
-            maxSize: this.props.ui.sidebarMaxWidth,
-        }
-    }
+  sidebarSplitSizing() {
+    return {
+      size: this.props.ui.sidebarHidden ? 1 : this.state.sidebarWidth,
+      minSize: this.props.ui.sidebarMinWidth,
+      defaultSize: this.props.ui.sidebarWidth,
+      maxSize: this.props.ui.sidebarMaxWidth,
+    };
+  }
 
-    getSidebarWidth() {
-        return this.props.ui.sidebarHidden ? 1 : this.state.sidebarWidth;
-    }
+  getSidebarWidth() {
+    return this.props.ui.sidebarHidden ? 1 : this.state.sidebarWidth;
+  }
 
-    editorSplitSizing() {
-        return {
-            size: this.getEditorHeight(),
-            defaultSize: this.getEditorHeight(),
-            minSize: 1,
-            maxSize: this.props.height - this.props.ui.replMinHeight,
-        }
-    }
+  editorSplitSizing() {
+    return {
+      size: this.getEditorHeight(),
+      defaultSize: this.getEditorHeight(),
+      minSize: 1,
+      maxSize: this.props.height - this.props.ui.replMinHeight,
+    };
+  }
 
-    getEditorHeight() {
-        return this.props.ui.replHidden ? this.props.height : this.state.editorHeight;
-    }
+  getEditorHeight() {
+    return this.props.ui.replHidden ? this.props.height : this.state.editorHeight;
+  }
 
-    editorSize() {
-        const sidebarWidth = this.getSidebarWidth()
-        const toolbarWidth = this.state.toolbarWidth;
-        const width = this.props.width - sidebarWidth - toolbarWidth - 1;
-        return {
-            width,
-            height: this.getEditorHeight(),
-        };
-    }
+  editorSize() {
+    const sidebarWidth = this.getSidebarWidth();
+    const toolbarWidth = this.state.toolbarWidth;
+    const width = this.props.width - sidebarWidth - toolbarWidth - 1;
+    return {
+      width,
+      height: this.getEditorHeight(),
+    };
+  }
 
-    editorToolsSize() {
-        return {
-            width: this.state.toolbarWidth,
-            height: this.getEditorHeight(),
-        };
-    }
+  editorToolsSize() {
+    return {
+      width: this.state.toolbarWidth,
+      height: this.getEditorHeight(),
+    };
+  }
 
-    getReplHeight() {
-        return this.props.height - this.getEditorHeight() - 1;
-    }
+  getReplHeight() {
+    return this.props.height - this.getEditorHeight() - 1;
+  }
 
-    replSize() {
-        return {
-            width: this.props.width - this.getSidebarWidth(),
-            height: this.getReplHeight(),
-        }
-    }
+  replSize() {
+    return {
+      width: this.props.width - this.getSidebarWidth(),
+      height: this.getReplHeight(),
+    };
+  }
 
     handleSidebarSplitChange = (size) => {
-        if (size <= this.props.ui.sidebarMinWidth && this.props.ui.sidebarHidden) {
-            // it is hidden so allow resize to reveal
-            this.props.sidebarToggle();
-        }
-        this.setState({
-            sidebarWidth: size,
-        });
+      if (size <= this.props.ui.sidebarMinWidth && this.props.ui.sidebarHidden) {
+        // it is hidden so allow resize to reveal
+        this.props.sidebarToggle();
+      }
+      this.setState({
+        sidebarWidth: size,
+      });
     }
 
     handleSidebarSplitDragFinish = () => {
-        this.props.sidebarSize(this.state.sidebarWidth)
+      this.props.sidebarSize(this.state.sidebarWidth);
     }
 
     handleEditorSplitChange = (size) => {
-        this.setState({
-            editorHeight: size
-        })
+      this.setState({
+        editorHeight: size,
+      });
     }
 
     handleEditorSplitDragFinish = () => {
-        this.props.replSize(this.getReplHeight());
+      this.props.replSize(this.getReplHeight());
     }
 
-    getActiveBuffer = () => {
-        return this.props.buffers.get(this.props.activeBuffer);
-    }
+    getActiveBuffer = () => this.props.buffers.get(this.props.activeBuffer)
 
     handleToolInvoke = (tool) => {
-        const buffer = this.getActiveBuffer()
-        const resource = this.props.activeBuffer;  // FIXME: this assumes the activeBuffer is a URL
+      const buffer = this.getActiveBuffer();
+      const resource = this.props.activeBuffer; // FIXME: this assumes the activeBuffer is a URL
 
-        if (!buffer) {
-            return
-        }
+      if (!buffer) {
+        return;
+      }
 
-        if (tool === 'save') {
-            if (buffer.get('modified')) {
-                this.editor.bufferWillSave(resource)
-                this.props.bufferSave(this.props.api, resource, this.editor.getValue(), () => {
-                    this.editor.bufferWasSaved(resource)
-                 })
-            }
+      if (tool === 'save') {
+        if (buffer.get('modified')) {
+          this.editor.bufferWillSave(resource);
+          this.props.bufferSave(this.props.api, resource, this.editor.getValue(), () => {
+            this.editor.bufferWasSaved(resource);
+          });
         }
-        else if (tool === 'play') {
-            if (buffer.get('modified')) {
-                // save, then run
-                this.editor.bufferWillSave(resource)
-                this.props.bufferSave(this.props.api, resource, this.editor.getValue(), () => {
-                    this.editor.bufferWasSaved(resource)
-                    this.props.scriptRun(this.props.api, resource)
-                })
-            }
-            else {
-                // not modified, just run
-                this.props.scriptRun(this.props.api, resource)
-            }
+      } else if (tool === 'play') {
+        if (buffer.get('modified')) {
+          // save, then run
+          this.editor.bufferWillSave(resource);
+          this.props.bufferSave(this.props.api, resource, this.editor.getValue(), () => {
+            this.editor.bufferWasSaved(resource);
+            this.props.scriptRun(this.props.api, resource);
+          });
+        } else {
+          // not modified, just run
+          this.props.scriptRun(this.props.api, resource);
         }
-        else {
-            // fallthrough behavior
-            this.props.toolInvoke(tool)
-        }
+      } else {
+        // fallthrough behavior
+        this.props.toolInvoke(tool);
+      }
     }
 
     handleResourceRename = (api, resource, name, virtual) => {
-        // MAINT: this annoying; rename changes names, urls, and active this/that which in turn causes a re-render. if the script being renamed is "virtual" then the editor buffer might contain changes which haven't been sync'd to the store. trigger a sync to ensure those changes aren't lost by the rename
-        if (virtual) {
-            console.log("syncing editor before rename just in case...")
-            this.props.bufferChange(this.props.activeBuffer, this.editor.getValue());
-        }
-        this.props.explorerResourceRename(api, resource, name, virtual);
+      // MAINT: this annoying; rename changes names, urls, and active this/that which in turn causes
+      // a re-render. if the script being renamed is "virtual" then the editor buffer might contain
+      // changes which haven't been sync'd to the store. trigger a sync to ensure those changes
+      // aren't lost by the rename
+      if (virtual) {
+        console.log('syncing editor before rename just in case...');
+        this.props.bufferChange(this.props.activeBuffer, this.editor.getValue());
+      }
+      this.props.explorerResourceRename(api, resource, name, virtual);
     }
 
     isText = (buffer) => {
-        if (buffer) {
-            return buffer.get("contentType").includes("text")
-        }
-        return false;
+      if (buffer) {
+        return buffer.get('contentType').includes('text');
+      }
+      return false;
     }
 
     render() {
-        const activeBuffer = this.props.activeBuffer;
-        const buffer = this.getActiveBuffer();
+      const activeBuffer = this.props.activeBuffer;
+      const buffer = this.getActiveBuffer();
 
-        const canEdit = this.isText(buffer);
-        const code = canEdit ? buffer.get('value') : '';
+      const canEdit = this.isText(buffer);
+      const code = canEdit ? buffer.get('value') : '';
 
-        const enabledTools = tools.map(t => {
-            t.disabled = !canEdit;
-            return t;
-        })
-        // TODO: switch editor based on buffer content type
-        const editor = (
-            <div className='editor-pane'>
-                <Editor
-                    className='editor-container'
-                    ref={(component) => {this.editor = component;}}
-                    { ...this.editorSize() }
-                    bufferName={activeBuffer}
-                    toolInvoke={this.handleToolInvoke}
-                    sidebarToggle={this.props.sidebarToggle}
-                    value={code}
-                    bufferChange={this.props.bufferChange}
-                />
-                <EditTools
-                    className='edit-tools'
-                    { ...this.editorToolsSize() }
-                    tools={enabledTools}
-                    buttonAction={this.handleToolInvoke}
-                />
-            </div>
-        )
+      /* eslint-disable no-param-reassign */
+      const enabledTools = tools.map((t) => {
+        t.disabled = !canEdit;
+        return t;
+      });
+      /* eslint-enable no-param-reassign */
 
-        const sidebarSplitStyle = {
-            height: this.props.height,
-            width: this.props.width,
-            position: "relative",   // must be inline to override library behavior
-        };
+      // TODO: switch editor based on buffer content type
+      const editor = (
+        <div className="editor-pane">
+          <Editor
+            className="editor-container"
+            ref={(component) => { this.editor = component; }}
+            {...this.editorSize()}
+            bufferName={activeBuffer}
+            toolInvoke={this.handleToolInvoke}
+            sidebarToggle={this.props.sidebarToggle}
+            value={code}
+            bufferChange={this.props.bufferChange}
+          />
+          <EditTools
+            className="edit-tools"
+            {...this.editorToolsSize()}
+            tools={enabledTools}
+            buttonAction={this.handleToolInvoke}
+          />
+        </div>
+      );
 
-        return (
-            <SplitPane
-                split='vertical'
-                style={sidebarSplitStyle}
-                { ...this.sidebarSplitSizing() }
-                onChange={this.handleSidebarSplitChange}
-                onDragFinished={this.handleSidebarSplitDragFinish}
-                paneClassName='editor-pane-common'
-            >
-                <Explorer
-                    className='explorer-container'
-                    hidden={this.props.ui.sidebarHidden}
-                    data={this.props.explorerData}
-                    bufferSelect={this.props.bufferSelect}
-                    directoryRead={this.props.directoryRead}
-                    scriptCreate={this.props.explorerScriptNew}
-                    scriptDuplicate={this.props.explorerScriptDuplicate}
-                    resourceDelete={this.props.explorerResourceDelete}
-                    resourceRename={this.handleResourceRename}
-                    explorerToggleNode={this.props.explorerToggleNode}
-                    explorerActiveNode={this.props.explorerActiveNode}
-                    api={this.props.api}
-                    activeBuffer={activeBuffer}
-                    activeNode={this.props.activeNode}
-                    showModal={this.props.showModal}
-                    hideModal={this.props.hideModal}
-                />
-                <SplitPane
-                    split='horizontal'
-                    { ...this.editorSplitSizing() }
-                    onChange={this.handleEditorSplitChange}
-                    onDragFinished={this.handleEditorSplitDragFinish}
-                >
-                    {editor}
-                    <ReplActivity
-                        { ...this.replSize() }
-                    />
-                </SplitPane>
-            </SplitPane>
-        );
+      const sidebarSplitStyle = {
+        height: this.props.height,
+        width: this.props.width,
+        position: 'relative', // must be inline to override library behavior
+      };
+
+      return (
+        <SplitPane
+          split="vertical"
+          style={sidebarSplitStyle}
+          {...this.sidebarSplitSizing()}
+          onChange={this.handleSidebarSplitChange}
+          onDragFinished={this.handleSidebarSplitDragFinish}
+          paneClassName="editor-pane-common"
+        >
+          <Explorer
+            className="explorer-container"
+            hidden={this.props.ui.sidebarHidden}
+            data={this.props.explorerData}
+            bufferSelect={this.props.bufferSelect}
+            directoryRead={this.props.directoryRead}
+            scriptCreate={this.props.explorerScriptNew}
+            scriptDuplicate={this.props.explorerScriptDuplicate}
+            resourceDelete={this.props.explorerResourceDelete}
+            resourceRename={this.handleResourceRename}
+            explorerToggleNode={this.props.explorerToggleNode}
+            explorerActiveNode={this.props.explorerActiveNode}
+            api={this.props.api}
+            activeBuffer={activeBuffer}
+            activeNode={this.props.activeNode}
+            showModal={this.props.showModal}
+            hideModal={this.props.hideModal}
+          />
+          <SplitPane
+            split="horizontal"
+            {...this.editorSplitSizing()}
+            onChange={this.handleEditorSplitChange}
+            onDragFinished={this.handleEditorSplitDragFinish}
+          >
+            {editor}
+            <ReplActivity
+              {...this.replSize()}
+            />
+          </SplitPane>
+        </SplitPane>
+      );
     }
 }
 

--- a/app/src/editor.js
+++ b/app/src/editor.js
@@ -3,30 +3,32 @@ import AceEditor from 'react-ace';
 
 import './editor.css';
 
+/* eslint-disable import/first */
 import 'brace/mode/lua';
 import 'brace/theme/dawn';
+/* eslint-enable import/first */
 
 class Editor extends Component {
-    constructor(props) {
-        super(props);
-        this.modified = false;
-    }
+  constructor(props) {
+    super(props);
+    this.modified = false;
+  }
 
     onLoad = (editor) => {
-        // grab reference to ace editor
-        this.editor = editor;
+      // grab reference to ace editor
+      this.editor = editor;
 
-        let session = this.editor.getSession();
-        session.setNewLineMode("unix");
-        session.setOptions({
-            tabSize: 2,        // MAINT: make this configurable
-            useSoftTabs: true,
-        });
+      const session = this.editor.getSession();
+      session.setNewLineMode('unix');
+      session.setOptions({
+        tabSize: 2, // MAINT: make this configurable
+        useSoftTabs: true,
+      });
 
-        // suppress the default print margin.
-        editor.setPrintMarginColumn(-1);
+      // suppress the default print margin.
+      editor.setPrintMarginColumn(-1);
 
-        /*
+      /*
         if (this.refs.ace) {
             window.setTimeout(() => {
                 this.refs.ace.editor.focus();
@@ -37,60 +39,62 @@ class Editor extends Component {
     }
 
     onChange = (event) => {
-        if (!this.modified) {
-            this.modified = true;
-            // we are consuming the first change, propagate the now modified buffer up
-            this.props.bufferChange(this.props.bufferName, event);
-        }
+      if (!this.modified) {
+        this.modified = true;
+        // we are consuming the first change, propagate the now modified buffer up
+        this.props.bufferChange(this.props.bufferName, event);
+      }
     }
 
-    getValue = () => {
-        return this.editor.getValue();
-    }
+    getValue = () => this.editor.getValue()
 
     bufferWillSave = (bufferName) => {
-        if (bufferName !== this.props.bufferName) {
-            console.log('buffer save mismatch ', bufferName, ' vs ', this.props.bufferName)
-        }
-        this.props.bufferChange(this.props.bufferName, this.getValue())
+      if (bufferName !== this.props.bufferName) {
+        console.log('buffer save mismatch ', bufferName, ' vs ', this.props.bufferName);
+      }
+      this.props.bufferChange(this.props.bufferName, this.getValue());
     }
 
     bufferWasSaved = (bufferName) => {
-        if (this.props.bufferName === bufferName) {
-            // MAINT: the edit-activity takes care of the modified flag on the buffer state and should call this method to in order to enable dirty
-            this.modified = false;
-        }
+      if (this.props.bufferName === bufferName) {
+        // MAINT: the edit-activity takes care of the modified flag on the buffer state and should
+        // call this method to in order to enable dirty
+        this.modified = false;
+      }
     }
 
     willChangeSize(newProps) {
-        return this.props.height !== newProps.height || this.props.width !== newProps.width;
+      return this.props.height !== newProps.height || this.props.width !== newProps.width;
     }
 
     componentWillReceiveProps(nextProps) {
-        if ((nextProps.bufferName !== this.props.bufferName ||
+      if ((nextProps.bufferName !== this.props.bufferName ||
              this.willChangeSize(nextProps)) && this.modified) {
-            // active buffer is being changed, sync current value to parent view before the editor is re-rendered
+        // active buffer is being changed, sync current value to parent view before the editor is
+        // re-rendered
 
-            if (this.props.bufferName) {
-                // only sync buffer if there is an actual name/resource
-                this.props.bufferChange(this.props.bufferName, this.getValue())
-            }
-
-            // reset dirty flag so that any change will mark (or remark) the buffer as dirty
-            this.modified = false;
-
-            // MAINT: work around a react-ace behavior; it restores the selection when the editor value prop changes but that means the selection is retained when switching between buffers too.
-            this.editor.clearSelection();
-
-            // MAINT: really lame, undo stack is global to the single wrapped editor so it extends across buffer switching. call undo repeatly will result in buffer switch (confusingly)
-            this.editor.getSession().getUndoManager().reset();
-
-            this.editor.getSession().setNewLineMode("unix");
+        if (this.props.bufferName) {
+          // only sync buffer if there is an actual name/resource
+          this.props.bufferChange(this.props.bufferName, this.getValue());
         }
+
+        // reset dirty flag so that any change will mark (or remark) the buffer as dirty
+        this.modified = false;
+
+        // MAINT: work around a react-ace behavior; it restores the selection when the editor value
+        // prop changes but that means the selection is retained when switching between buffers too.
+        this.editor.clearSelection();
+
+        // MAINT: really lame, undo stack is global to the single wrapped editor so it extends
+        // across buffer switching. call undo repeatly will result in buffer switch (confusingly)
+        this.editor.getSession().getUndoManager().reset();
+
+        this.editor.getSession().setNewLineMode('unix');
+      }
     }
 
     componentWillUnmount() {
-        this.props.bufferChange(this.props.bufferName, this.getValue())
+      this.props.bufferChange(this.props.bufferName, this.getValue());
     }
 
     /*
@@ -106,44 +110,44 @@ class Editor extends Component {
     }
     */
 
-    render () {
-        const width = `${this.props.width}px`;
-        const height = `${this.props.height}px`;
+    render() {
+      const width = `${this.props.width}px`;
+      const height = `${this.props.height}px`;
 
-        return (
-            <AceEditor
-                ref="ace"
-                mode="lua"
-                theme="dawn"
-                width={width}
-                height={height}
-                value={this.props.value}
-                onLoad={this.onLoad}
-                onChange={this.onChange}
-                showPrintMargin={false}
-                commands={[
-                  {  
+      return (
+        <AceEditor
+          ref="ace"
+          mode="lua"
+          theme="dawn"
+          width={width}
+          height={height}
+          value={this.props.value}
+          onLoad={this.onLoad}
+          onChange={this.onChange}
+          showPrintMargin={false}
+          commands={[
+                  {
                     name: 'save',
-                    bindKey: { win: "Ctrl-S", mac: "Command-S" },
+                    bindKey: { win: 'Ctrl-S', mac: 'Command-S' },
                     exec: () => this.props.toolInvoke('save'),
                   },
                   {
                     name: 'play',
-                    bindKey: { win: "Ctrl-P", mac: "Command-P" },
+                    bindKey: { win: 'Ctrl-P', mac: 'Command-P' },
                     exec: () => this.props.toolInvoke('play'),
                   },
                   {
                     name: 'toggle sidebar',
-                    bindKey: { win: "Ctrl-B", mac: "Command-B" },
+                    bindKey: { win: 'Ctrl-B', mac: 'Command-B' },
                     exec: () => this.props.sidebarToggle(),
-                  },                
+                  },
                 ]}
-                editorProps={{
+          editorProps={{
                     $blockScrolling: Infinity,
-                    $newLineMode: "unix",
+                    $newLineMode: 'unix',
                 }}
-            />
-        );
+        />
+      );
     }
 }
 

--- a/app/src/explorer.js
+++ b/app/src/explorer.js
@@ -11,380 +11,382 @@ import IconButton from './icon-button';
 import { ICONS } from './svg-icons';
 
 const TreeHeader = (props) => {
-    let className = cx('explorer-entry', 'noselect', {'dirty': props.node.modified}, {'active': props.node.active});
-    return (
-        <span className={className}>
-            {props.node.name}
-        </span>
-    );
+  const className = cx('explorer-entry', 'noselect', { dirty: props.node.modified }, { active: props.node.active });
+  return (
+    <span className={className}>
+      {props.node.name}
+    </span>
+  );
 };
 
-const TreeToggle = ({style}) => {
-    const {height, width} = style;
-    const midHeight = height * 0.5;
-    const points = `0,0 0,${height} ${width},${midHeight}`;
+const TreeToggle = ({ style }) => {
+  const { height, width } = style;
+  const midHeight = height * 0.5;
+  const points = `0,0 0,${height} ${width},${midHeight}`;
 
-    return (
-        <span className="explorer-tree-toggle" style={style.base}>
-            <svg height={height} width={width}>
-                <polygon points={points} style={style.arrow} />
-            </svg>
-        </span>
-    );
+  return (
+    <span className="explorer-tree-toggle" style={style.base}>
+      <svg height={height} width={width}>
+        <polygon points={points} style={style.arrow} />
+      </svg>
+    </span>
+  );
 };
 
 const explorerDecorators = {
-    ...decorators,
-    Header: TreeHeader,
-    Toggle: TreeToggle,
+  ...decorators,
+  Header: TreeHeader,
+  Toggle: TreeToggle,
 };
 
-// TODO: turn this in a containing component called Section so that individual sections can be collapsed and expanded
+// TODO: turn this in a containing component called Section so that individual sections can be
+// collapsed and expanded
 const SectionHeader = (props) => {
-    let tools = props.tools.map(tool => {
-        return (
-            <IconButton
-                key={tool.name}
-                tooltipMessage={tool.tooltipMessage}
-                tooltipPosition={tool.tooltipPosition}
-                action={() => props.buttonAction(tool.name)}
-                icon={tool.icon}
-                size="12"
-                padding="1"
-                color="#e4e4e4"
-            />
-        );
-    });
+  const tools = props.tools.map(tool => (
+    <IconButton
+      key={tool.name}
+      tooltipMessage={tool.tooltipMessage}
+      tooltipPosition={tool.tooltipPosition}
+      action={() => props.buttonAction(tool.name)}
+      icon={tool.icon}
+      size="12"
+      padding="1"
+      color="#e4e4e4"
+    />
+  ));
 
-    return (
-        <div className='explorer-header'>
-            <span className='section-name'>{props.name}</span>
-            <span
-                className={cx('section-tools', {'opaque': props.showTools})}
-            >
-                {tools}
-            </span>
-        </div>
-    );
-}
+  return (
+    <div className="explorer-header">
+      <span className="section-name">{props.name}</span>
+      <span
+        className={cx('section-tools', { opaque: props.showTools })}
+      >
+        {tools}
+      </span>
+    </div>
+  );
+};
 
 class Section extends Component {
-    constructor(props) {
-        super(props)
-        this.state = {
-            showTools: false,
-            selectedNode: undefined,
-        }
-    }
+  constructor(props) {
+    super(props);
+    this.state = {
+      showTools: false,
+      selectedNode: undefined,
+    };
+  }
 
-    componentDidMount() {
-        this.section.onmouseenter = (e) => {
-            this.setState({
-                showTools: true,
-            })
-        }
-        this.section.onmouseleave = (e) => {
-            this.setState({
-                showTools: false,
-            })
-        }
-    }
-    
+  componentDidMount() {
+    this.section.onmouseenter = (_e) => {
+      this.setState({
+        showTools: true,
+      });
+    };
+    this.section.onmouseleave = (_e) => {
+      this.setState({
+        showTools: false,
+      });
+    };
+  }
+
     onToggle = (node, toggled) => {
-        if (node.children) {
-            this.props.explorerToggleNode(node, toggled)
-            if (toggled) {
-                this.props.directoryRead(this.props.api, node.url);
-            }
-        } else {
-            this.props.bufferSelect(node.url);
+      if (node.children) {
+        this.props.explorerToggleNode(node, toggled);
+        if (toggled) {
+          this.props.directoryRead(this.props.api, node.url);
         }
+      } else {
+        this.props.bufferSelect(node.url);
+      }
 
-        this.setState({ selectedNode: node });
+      this.setState({ selectedNode: node });
     }
 
     onToolClick = (name) => {
-        // add doesn't (necessarily) require a selection
-        if (name === 'add') {
-            let selection = undefined;
-            if (this.state.selectedNode) {
-                selection = this.state.selectedNode.url;
-            }
-            this.props.scriptCreate(
-                selection,                // sibling resource
-                undefined,                // initial buffer contents
-                undefined,                // buffer name
-                this.props.name);         // buffer category
-            return;
+      // add doesn't (necessarily) require a selection
+      if (name === 'add') {
+        let selection;
+        if (this.state.selectedNode) {
+          selection = this.state.selectedNode.url;
         }
-        
-        // other tools only function if there is a selection, ensure there is one and it is from this category
-        let activeBuffer = this.props.activeBuffer;
-        if (activeBuffer === undefined) {
-            return;
-        }
+        this.props.scriptCreate(
+          selection, // sibling resource
+          undefined, // initial buffer contents
+          undefined, // buffer name
+          this.props.name,
+        ); // buffer category
+        return;
+      }
 
-        let category = this.props.api.categoryFromResource(activeBuffer);
-        if (category !== this.props.name) {
-            console.log("ignoring tool, active buffer is not in category", category);
-            return;
-        }
+      // other tools only function if there is a selection, ensure there is one and it is from this
+      // category
+      const activeBuffer = this.props.activeBuffer;
+      if (activeBuffer === undefined) {
+        return;
+      }
 
-        /*
+      const category = this.props.api.categoryFromResource(activeBuffer);
+      if (category !== this.props.name) {
+        console.log('ignoring tool, active buffer is not in category', category);
+        return;
+      }
+
+      /*
         STOPPED HERE; use CATEGORY to gate invocation instead of selectionURL != activeBuffer stuff.
 
         ensure duplicate then remove/rename works w/out having to reselect the item
 
         ensure script create puts a new file in the correct category
 */
-        switch (name) {
+      switch (name) {
         case 'duplicate':
-            this.props.scriptDuplicate(this.props.activeBuffer)
-            break;
+          this.props.scriptDuplicate(this.props.activeBuffer);
+          break;
 
         case 'remove':
-            this.handleRemove(this.props.activeNode)
-            break;
+          this.handleRemove(this.props.activeNode);
+          break;
 
         case 'rename':
-            this.handleRename(this.props.activeNode)
-            break;
+          this.handleRename(this.props.activeNode);
+          break;
 
         default:
-            console.log(name)
-            break;
-        }
+          console.log(name);
+          break;
+      }
     }
 
     handleRemove = (selection) => {
-        if (selection === undefined) {
-            console.log("handleRemove: selection undefined?")
-            return
+      if (selection === undefined) {
+        console.log('handleRemove: selection undefined?');
+        return;
+      }
+
+      const removeModalCompletion = (choice) => {
+        console.log('remove:', choice);
+        if (choice === 'ok') {
+          this.props.resourceDelete(this.props.api, selection.get('url'));
         }
+        this.props.hideModal();
+      };
 
-        let removeModalCompletion = (choice) => {
-            console.log('remove:', choice)
-            if (choice === 'ok') {
-                this.props.resourceDelete(this.props.api, selection.get("url"))
-            }
-            this.props.hideModal()
-        }
+      const scriptName = selection.get('name');
+      const content = (
+        <ModalContent
+          message={`Delete "${scriptName}"?`}
+          supporting="This operation cannot be undone."
+          buttonAction={removeModalCompletion}
+        />
+      );
 
-        let scriptName = selection.get("name")
-        let content = (
-            <ModalContent
-                message={`Delete "${scriptName}"?`}
-                supporting={"This operation cannot be undone."}
-                buttonAction={removeModalCompletion}
-            />
-        )
-
-        this.props.showModal(content)
+      this.props.showModal(content);
     }
 
     handleRename = (selection) => {
-        if (selection === undefined) {
-            console.log("handleRename: selection undefined?")
-            return
+      if (selection === undefined) {
+        console.log('handleRename: selection undefined?');
+        return;
+      }
+
+      const complete = (choice, name) => {
+        console.log('rename:', choice, name);
+        if (name && choice === 'ok') {
+          this.props.resourceRename(
+            this.props.api,
+            selection.get('url'),
+            name,
+            selection.get('virtual') || false,
+          );
         }
+        this.props.hideModal();
+      };
 
-        let complete = (choice, name) => {
-            console.log('rename:', choice, name)
-            if (name && choice === "ok") {
-                this.props.resourceRename(
-                    this.props.api,
-                    selection.get("url"),
-                    name,
-                    selection.get("virtual") || false
-                )
-            }
-            this.props.hideModal()
-        }
+      const initialName = selection.get('name');
+      const content = (
+        <ModalRename message="Rename" buttonAction={complete} initialName={initialName} />
+      );
 
-        let initialName = selection.get("name");
-        let content = (
-            <ModalRename message="Rename" buttonAction={complete} initialName={initialName} />
-        )
-
-        this.props.showModal(content)
+      this.props.showModal(content);
     }
 
 
     getData() {
-        let node = this.props.data.find(n => n.name === this.props.name)
-        if (node) {
-            return node.children;
-        }
-        return [];
+      const node = this.props.data.find(n => n.name === this.props.name);
+      if (node) {
+        return node.children;
+      }
+      return [];
     }
 
     render() {
-        let data = this.getData()
+      const data = this.getData();
 
-        return (
-            <div
-                className='explorer-section'
-                ref={(elem) => this.section = elem}
-            >
-                <SectionHeader
-                    name={this.props.name}
-                    tools={this.props.tools}
-                    buttonAction={this.onToolClick}
-                    showTools={this.state.showTools}
-                />
-                <Treebeard
-                    style={treeStyle}
-                    animations={treeAnim}
-                    data={data}
-                    onToggle={this.onToggle}
-                    decorators={explorerDecorators}
-                />
-            </div>
-        );
+      return (
+        <div
+          className="explorer-section"
+          ref={elem => this.section = elem}
+        >
+          <SectionHeader
+            name={this.props.name}
+            tools={this.props.tools}
+            buttonAction={this.onToolClick}
+            showTools={this.state.showTools}
+          />
+          <Treebeard
+            style={treeStyle}
+            animations={treeAnim}
+            data={data}
+            onToggle={this.onToggle}
+            decorators={explorerDecorators}
+          />
+        </div>
+      );
     }
 }
 
 const scriptTools = [
-    {
-        name: "add",
-        icon: ICONS["plus"],
-        tooltipMessage: "new script"
-    },
-    {
-        name: "remove",
-        icon: ICONS["minus"],
-        tooltipMessage: "delete script"
-    },
-    {
-        name: "duplicate",
-        icon: ICONS["copy"],
-        tooltipMessage: "duplicate script"
-    },
-    {
-        name: "new-folder",
-        icon: ICONS["folder-plus"],
-        tooltipMessage: "new folder"
-    },
-    {
-        name: "rename",
-        icon: ICONS["pencil"],
-        tooltipMessage: "rename file/folder"
-    },
-]
+  {
+    name: 'add',
+    icon: ICONS.plus,
+    tooltipMessage: 'new script',
+  },
+  {
+    name: 'remove',
+    icon: ICONS.minus,
+    tooltipMessage: 'delete script',
+  },
+  {
+    name: 'duplicate',
+    icon: ICONS.copy,
+    tooltipMessage: 'duplicate script',
+  },
+  {
+    name: 'new-folder',
+    icon: ICONS['folder-plus'],
+    tooltipMessage: 'new folder',
+  },
+  {
+    name: 'rename',
+    icon: ICONS.pencil,
+    tooltipMessage: 'rename file/folder',
+  },
+];
 
 const audioTools = [
-    {
-        name: "remove",
-        icon: ICONS["minus"],
-        tooltipMessage: "delete audio file"
-    },
-    {
-        name: "new-folder",
-        icon: ICONS["folder-plus"],
-        tooltipMessage: "new folder"
-    },
-    {
-        name: "rename",
-        icon: ICONS["pencil"],
-        tooltipMessage: "rename file/folder"
-    },
-]
+  {
+    name: 'remove',
+    icon: ICONS.minus,
+    tooltipMessage: 'delete audio file',
+  },
+  {
+    name: 'new-folder',
+    icon: ICONS['folder-plus'],
+    tooltipMessage: 'new folder',
+  },
+  {
+    name: 'rename',
+    icon: ICONS.pencil,
+    tooltipMessage: 'rename file/folder',
+  },
+];
 
 const dataTools = [
-    {
-        name: "add",
-        icon: ICONS["plus"],
-        tooltipMessage: "new data file"
-    },
-    {
-        name: "remove",
-        icon: ICONS["minus"],
-        tooltipMessage: "delete data file"
-    },
-    {
-        name: "duplicate",
-        icon: ICONS["copy"],
-        tooltipMessage: "duplicate data file"
-    },
-    {
-        name: "new-folder",
-        icon: ICONS["folder-plus"],
-        tooltipMessage: "new folder"
-    },
-    {
-        name: "rename",
-        icon: ICONS["pencil"],
-        tooltipMessage: "rename file/folder"
-    },
-]
+  {
+    name: 'add',
+    icon: ICONS.plus,
+    tooltipMessage: 'new data file',
+  },
+  {
+    name: 'remove',
+    icon: ICONS.minus,
+    tooltipMessage: 'delete data file',
+  },
+  {
+    name: 'duplicate',
+    icon: ICONS.copy,
+    tooltipMessage: 'duplicate data file',
+  },
+  {
+    name: 'new-folder',
+    icon: ICONS['folder-plus'],
+    tooltipMessage: 'new folder',
+  },
+  {
+    name: 'rename',
+    icon: ICONS.pencil,
+    tooltipMessage: 'rename file/folder',
+  },
+];
 
 
 class Explorer extends Component {
-    render() {
-        const {width, height} = this.props;
+  render() {
+    const { width, height } = this.props;
 
-        return (
-            <div className={'explorer' + (this.props.hidden ? ' hidden' : '')} // FIXME: change this to use classname
-                style={{width, height}}
-                ref={(elem) => this.explorer = elem}
-            >
-                <Section
-                    name='scripts'
-                    tools={scriptTools}
-                    buttonAction={this.onToolClick}
-                    data={this.props.data}
-                    explorerToggleNode={this.props.explorerToggleNode}
-                    bufferSelect={this.props.bufferSelect}
-                    directoryRead={this.props.directoryRead}
-                    scriptCreate={this.props.scriptCreate}
-                    scriptDuplicate={this.props.scriptDuplicate}
-                    resourceDelete={this.props.resourceDelete}
-                    resourceRename={this.props.resourceRename}
-                    showModal={this.props.showModal}
-                    hideModal={this.props.hideModal}
-                    api={this.props.api}
-                    activeBuffer={this.props.activeBuffer}
-                    activeNode={this.props.activeNode}
-                />
-                <Section
-                    name='audio'
-                    tools={audioTools}
-                    buttonAction={this.onToolClick}
-                    data={this.props.data}
-                    explorerToggleNode={this.props.explorerToggleNode}
-                    bufferSelect={this.props.bufferSelect}
-                    scriptCreate={this.props.scriptCreate}
-                    scriptDuplicate={this.props.scriptDuplicate}
-                    directoryRead={this.props.directoryRead}
-                    resourceDelete={this.props.resourceDelete}
-                    resourceRename={this.props.resourceRename}
-                    showModal={this.props.showModal}
-                    hideModal={this.props.hideModal}
-                    api={this.props.api}
-                    activeBuffer={this.props.activeBuffer}
-                    activeNode={this.props.activeNode}
-                />
-                <Section
-                    name='data'
-                    tools={dataTools}
-                    buttonAction={this.onToolClick}
-                    data={this.props.data}
-                    explorerToggleNode={this.props.explorerToggleNode}
-                    bufferSelect={this.props.bufferSelect}
-                    scriptCreate={this.props.scriptCreate}
-                    scriptDuplicate={this.props.scriptDuplicate}
-                    directoryRead={this.props.directoryRead}
-                    resourceDelete={this.props.resourceDelete}
-                    resourceRename={this.props.resourceRename}
-                    showModal={this.props.showModal}
-                    hideModal={this.props.hideModal}
-                    api={this.props.api}
-                    activeBuffer={this.props.activeBuffer}
-                    activeNode={this.props.activeNode}
-                />
-            </div>
-        );
-    }
+    return (
+      <div
+        className={`explorer${this.props.hidden ? ' hidden' : ''}`} // FIXME: change this to use classname
+        style={{ width, height }}
+        ref={elem => this.explorer = elem}
+      >
+        <Section
+          name="scripts"
+          tools={scriptTools}
+          buttonAction={this.onToolClick}
+          data={this.props.data}
+          explorerToggleNode={this.props.explorerToggleNode}
+          bufferSelect={this.props.bufferSelect}
+          directoryRead={this.props.directoryRead}
+          scriptCreate={this.props.scriptCreate}
+          scriptDuplicate={this.props.scriptDuplicate}
+          resourceDelete={this.props.resourceDelete}
+          resourceRename={this.props.resourceRename}
+          showModal={this.props.showModal}
+          hideModal={this.props.hideModal}
+          api={this.props.api}
+          activeBuffer={this.props.activeBuffer}
+          activeNode={this.props.activeNode}
+        />
+        <Section
+          name="audio"
+          tools={audioTools}
+          buttonAction={this.onToolClick}
+          data={this.props.data}
+          explorerToggleNode={this.props.explorerToggleNode}
+          bufferSelect={this.props.bufferSelect}
+          scriptCreate={this.props.scriptCreate}
+          scriptDuplicate={this.props.scriptDuplicate}
+          directoryRead={this.props.directoryRead}
+          resourceDelete={this.props.resourceDelete}
+          resourceRename={this.props.resourceRename}
+          showModal={this.props.showModal}
+          hideModal={this.props.hideModal}
+          api={this.props.api}
+          activeBuffer={this.props.activeBuffer}
+          activeNode={this.props.activeNode}
+        />
+        <Section
+          name="data"
+          tools={dataTools}
+          buttonAction={this.onToolClick}
+          data={this.props.data}
+          explorerToggleNode={this.props.explorerToggleNode}
+          bufferSelect={this.props.bufferSelect}
+          scriptCreate={this.props.scriptCreate}
+          scriptDuplicate={this.props.scriptDuplicate}
+          directoryRead={this.props.directoryRead}
+          resourceDelete={this.props.resourceDelete}
+          resourceRename={this.props.resourceRename}
+          showModal={this.props.showModal}
+          hideModal={this.props.hideModal}
+          api={this.props.api}
+          activeBuffer={this.props.activeBuffer}
+          activeNode={this.props.activeNode}
+        />
+      </div>
+    );
+  }
 }
 
 export default Explorer;

--- a/app/src/icon-button.js
+++ b/app/src/icon-button.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import Icon from './icon';
 import ReactTooltip from 'react-tooltip';
+import Icon from './icon';
 import './icon-button.css';
 
 // TODO:
@@ -9,48 +9,48 @@ import './icon-button.css';
 
 class IconButton extends Component {
     handleClick = () => {
-        if (!this.props.disabled) {
-            this.props.action()
-        }
+      if (!this.props.disabled) {
+        this.props.action();
+      }
     }
 
     getColor = () => {
-        if (this.props.disabledColor && this.props.disabled) {
-            return this.props.disabledColor;
-        }
-        return this.props.color;
+      if (this.props.disabledColor && this.props.disabled) {
+        return this.props.disabledColor;
+      }
+      return this.props.color;
     }
 
     render() {
-        let style = { padding: this.props.padding || 6 };
-        let color = this.getColor();
-        let tooltipPosition = this.props.tooltipPosition || "bottom";
-        
-        function guid() {
-            function s4() {
-              return Math.floor((1 + Math.random()) * 0x10000)
-                .toString(16)
-                .substring(1);
-            }
-            return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
-        }
-        
-        let uniqueId = guid();
+      const style = { padding: this.props.padding || 6 };
+      const color = this.getColor();
+      const tooltipPosition = this.props.tooltipPosition || 'bottom';
 
-        return (
-            <button
-                className="icon-button"
-                onClick={this.handleClick}
-                data-tip={this.props.tooltipMessage}
-                data-place={this.props.tooltipMessage && tooltipPosition}
-                data-for={this.props.tooltipMessage && uniqueId}
-                style={style}
-            >
-                <Icon icon={this.props.icon} size={this.props.size} color={color}/>
-                {this.props.tooltipMessage && <ReactTooltip id={uniqueId} effect="solid" delayShow={1000} delayHide={500} className="customTooltip"></ReactTooltip>}
-            </button>
-        );
+      function guid() {
+        function s4() {
+          return Math.floor((1 + Math.random()) * 0x10000)
+            .toString(16)
+            .substring(1);
+        }
+        return `${s4() + s4()}-${s4()}-${s4()}-${s4()}-${s4()}${s4()}${s4()}`;
+      }
+
+      const uniqueId = guid();
+
+      return (
+        <button
+          className="icon-button"
+          onClick={this.handleClick}
+          data-tip={this.props.tooltipMessage}
+          data-place={this.props.tooltipMessage && tooltipPosition}
+          data-for={this.props.tooltipMessage && uniqueId}
+          style={style}
+        >
+          <Icon icon={this.props.icon} size={this.props.size} color={color} />
+          {this.props.tooltipMessage && <ReactTooltip id={uniqueId} effect="solid" delayShow={1000} delayHide={500} className="customTooltip" />}
+        </button>
+      );
     }
-};
+}
 
 export default IconButton;

--- a/app/src/modal-content.js
+++ b/app/src/modal-content.js
@@ -17,8 +17,8 @@ const ModalContent = props => (
       <IconButton
         key="cancel"
         action={() => props.buttonAction('cancel')}
-        tooltipMessage='cancel'
-        tooltipPosition='top'
+        tooltipMessage="cancel"
+        tooltipPosition="top"
         icon={ICONS.cross}
         color="#979797" // FIXME:
         size="24"
@@ -26,8 +26,8 @@ const ModalContent = props => (
       <IconButton
         key="ok"
         action={() => props.buttonAction('ok')}
-        tooltipMessage='ok'
-        tooltipPosition='top'
+        tooltipMessage="ok"
+        tooltipPosition="top"
         icon={ICONS.check}
         color="#979797" // FIXME:
         size="30"

--- a/app/src/modal-rename.js
+++ b/app/src/modal-rename.js
@@ -6,112 +6,110 @@ import { ICONS } from './svg-icons';
 import { INVALID_NAME_CHARS } from './constants';
 
 const mapStateToProps = (state) => {
-    // renaming is relative to some active node; get sibling names to enable validation
-    let siblingNames = siblingNamesForResource(state.edit.rootNodes, state.edit.activeBuffer);
-    return {
-        siblingNames,
-    }
-}
+  // renaming is relative to some active node; get sibling names to enable validation
+  const siblingNames = siblingNamesForResource(state.edit.rootNodes, state.edit.activeBuffer);
+  return {
+    siblingNames,
+  };
+};
 
 class ModalRename extends Component {
-    constructor(props) {
-        super(props)
-        this.textArea = undefined
-        this.state = {
-            showError: false,
-            errorMessage: "",
-        }
-    }
-    
+  constructor(props) {
+    super(props);
+    this.textArea = undefined;
+    this.state = {
+      showError: false,
+      errorMessage: '',
+    };
+  }
+
     handleKeyDown = (event) => {
-        // filter out chars we can't have in names
-        if (INVALID_NAME_CHARS.has(event.key)) {
-            console.log("character '", event.key, "' not allowed in names")
-            event.preventDefault()
-            return;
-        }
+      // filter out chars we can't have in names
+      if (INVALID_NAME_CHARS.has(event.key)) {
+        console.log("character '", event.key, "' not allowed in names");
+        event.preventDefault();
+        return;
+      }
 
-        switch (event.keyCode) {
-         case 13:            // return
-            event.preventDefault()
-            this.complete('ok')
-            break;
+      switch (event.keyCode) {
+        case 13: // return
+          event.preventDefault();
+          this.complete('ok');
+          break;
 
-        case 27:            // escape
-            event.preventDefault()
-            this.complete('cancel')
-            break;
+        case 27: // escape
+          event.preventDefault();
+          this.complete('cancel');
+          break;
 
         default:
-            break;
-        }
+          break;
+      }
     }
 
-    handleOnChange = (event) => {
-        if (this.props.siblingNames.has(this.textArea.value)) {
-            this.setState({
-                errorMessage: "name already in use",
-            })
-        } else {
-            this.setState({
-                errorMessage: "",
-            })
-        }
+    handleOnChange = (_event) => {
+      if (this.props.siblingNames.has(this.textArea.value)) {
+        this.setState({
+          errorMessage: 'name already in use',
+        });
+      } else {
+        this.setState({
+          errorMessage: '',
+        });
+      }
     }
 
-    isValidName = (name) => {
-        return !this.props.siblingNames.has(name);
-    }
+    isValidName = name => !this.props.siblingNames.has(name)
 
 
     complete = (choice) => {
-        let name = this.textArea.value;
-        if (choice === "ok" && !this.isValidName(name)) {
-            // prevent completion if name is bad
-            return
-        }
-        this.props.buttonAction(choice, this.textArea.value)
+      const name = this.textArea.value;
+      if (choice === 'ok' && !this.isValidName(name)) {
+        // prevent completion if name is bad
+        return;
+      }
+      this.props.buttonAction(choice, this.textArea.value);
     }
 
     render() {
-        return (
-            <div className="modal-content">
-            <div className="message-container">
-                <span className="message">{this.props.message}</span>
-                <p/>
-            </div>
-            <textarea
-                    className="rename-modal-text-area"
-                    ref={(e) => this.textArea = e}
-                    placeholder={this.props.initialName}
-                    rows="1"
-                    maxLength="128"
-                    wrap="false"
-                    autoFocus="true"
-                    onKeyDown={this.handleKeyDown}
-                    onChange={this.handleOnChange}
-                />
-            <div className="rename-modal-error-message">
-                {this.state.errorMessage}
-            </div>
-            <div className="button-container">
-                <IconButton
-                    key='cancel'
-                    action={() => this.complete('cancel')}
-                    icon={ICONS['cross']}
-                    color="#979797"   // FIXME:
-                    size="24"
-                />
-                <IconButton
-                    key='ok'
-                    action={() => this.complete('ok')}
-                    icon={ICONS['check']}
-                    color="#979797"   // FIXME:
-                    size="30"
-                />
-            </div>
-            </div>
-        )
+      return (
+        <div className="modal-content">
+          <div className="message-container">
+            <span className="message">{this.props.message}</span>
+            <p />
+          </div>
+          <textarea
+            className="rename-modal-text-area"
+            ref={e => this.textArea = e}
+            placeholder={this.props.initialName}
+            rows="1"
+            maxLength="128"
+            wrap="false"
+            autoFocus="true"
+            onKeyDown={this.handleKeyDown}
+            onChange={this.handleOnChange}
+          />
+          <div className="rename-modal-error-message">
+            {this.state.errorMessage}
+          </div>
+          <div className="button-container">
+            <IconButton
+              key="cancel"
+              action={() => this.complete('cancel')}
+              icon={ICONS.cross}
+              color="#979797" // FIXME:
+              size="24"
+            />
+            <IconButton
+              key="ok"
+              action={() => this.complete('ok')}
+              icon={ICONS.check}
+              color="#979797" // FIXME:
+              size="30"
+            />
+          </div>
+        </div>
+      );
     }
 }
 

--- a/app/src/model/edit-actions.js
+++ b/app/src/model/edit-actions.js
@@ -53,19 +53,46 @@ export const bufferReadSuccess = (resource, value, contentType) => ({
   type: BUFFER_READ_SUCCESS, resource, value, contentType,
 });
 
-export const bufferReadFailure = (resource, error) => ({ type: BUFFER_READ_FAILURE, resource, error });
+export const bufferReadFailure = (resource, error) => ({
+  type: BUFFER_READ_FAILURE,
+  resource,
+  error,
+});
 
-export const directoryReadRequest = resource => ({ type: DIRECTORY_READ_REQUEST, resource });
+export const directoryReadRequest = resource => ({
+  type: DIRECTORY_READ_REQUEST,
+  resource,
+});
 
-export const directoryReadSuccess = (resource, value) => ({ type: DIRECTORY_READ_SUCCESS, resource, value });
+export const directoryReadSuccess = (resource, value) => ({
+  type: DIRECTORY_READ_SUCCESS,
+  resource,
+  value,
+});
 
-export const directoryReadFailure = (resource, error) => ({ type: DIRECTORY_READ_FAILURE, resource, error });
+export const directoryReadFailure = (resource, error) => ({
+  type: DIRECTORY_READ_FAILURE,
+  resource,
+  error,
+});
 
-export const bufferSaveRequest = (resource, value) => ({ type: BUFFER_SAVE_REQUEST, resource, value });
+export const bufferSaveRequest = (resource, value) => ({
+  type: BUFFER_SAVE_REQUEST,
+  resource,
+  value,
+});
 
-export const bufferSaveSuccess = (resource, value) => ({ type: BUFFER_SAVE_SUCCESS, resource, value });
+export const bufferSaveSuccess = (resource, value) => ({
+  type: BUFFER_SAVE_SUCCESS,
+  resource,
+  value,
+});
 
-export const bufferSaveFailure = (resource, error) => ({ type: BUFFER_SAVE_FAILURE, resource, error });
+export const bufferSaveFailure = (resource, error) => ({
+  type: BUFFER_SAVE_FAILURE,
+  resource,
+  error,
+});
 
 export const bufferChange = (resource, value) => ({ type: BUFFER_CHANGE, resource, value });
 
@@ -77,7 +104,11 @@ export const scriptNew = (siblingResource, value, name, category) => ({
 
 export const scriptDuplicate = resource => ({ type: SCRIPT_DUPLICATE, resource });
 
-export const resourceRenameRequest = (resource, name) => ({ type: RESOURCE_RENAME_REQUEST, resource, name });
+export const resourceRenameRequest = (resource, name) => ({
+  type: RESOURCE_RENAME_REQUEST,
+  resource,
+  name,
+});
 
 export const resourceRenameSuccess = (resource, newName, newResource) => ({
   type: RESOURCE_RENAME_SUCCESS, resource, newName, newResource,
@@ -87,24 +118,51 @@ export const resourceRenameFailure = (resource, name, error) => ({
   type: RESOURCE_RENAME_FAILURE, resource, name, error,
 });
 
-export const directoryCreateRequest = (siblingResource, name) => ({ type: DIRECTORY_CREATE_REQUEST, siblingResource, name });
+export const directoryCreateRequest = (siblingResource, name) => ({
+  type: DIRECTORY_CREATE_REQUEST,
+  siblingResource,
+  name,
+});
 
-export const directoryCreateSuccess = resource => ({ type: DIRECTORY_CREATE_SUCCESS, resource });
+export const directoryCreateSuccess = resource => ({
+  type: DIRECTORY_CREATE_SUCCESS,
+  resource,
+});
 
-export const directoryCreateFailure = (resource, error) => ({ type: DIRECTORY_CREATE_FAILURE, resource, error });
+export const directoryCreateFailure = (resource, error) => ({
+  type: DIRECTORY_CREATE_FAILURE,
+  resource,
+  error,
+});
 
-export const resourceDeleteRequest = resource => ({ type: RESOURCE_DELETE_REQUEST, resource });
+export const resourceDeleteRequest = resource => ({
+  type: RESOURCE_DELETE_REQUEST,
+  resource,
+});
 
-export const resourceDeleteSuccess = resource => ({ type: RESOURCE_DELETE_SUCCESS, resource });
+export const resourceDeleteSuccess = resource => ({
+  type: RESOURCE_DELETE_SUCCESS,
+  resource,
+});
 
-export const resourceDeleteFailure = (resource, error) => ({ type: RESOURCE_DELETE_FAILURE, resource, error });
-
+export const resourceDeleteFailure = (resource, error) => ({
+  type: RESOURCE_DELETE_FAILURE,
+  resource,
+  error,
+});
 
 export const toolInvoke = name => ({ type: TOOL_INVOKE, name });
 
-export const explorerActiveNode = node => ({ type: EXPLORER_ACTIVE_NODE, node });
+export const explorerActiveNode = node => ({
+  type: EXPLORER_ACTIVE_NODE,
+  node,
+});
 
-export const explorerToggleNode = (node, toggled) => ({ type: EXPLORER_TOGGLE_NODE, node, toggled });
+export const explorerToggleNode = (node, toggled) => ({
+  type: EXPLORER_TOGGLE_NODE,
+  node,
+  toggled,
+});
 
 //
 // async actions
@@ -166,7 +224,9 @@ export const bufferSave = (api, resource, value, cb) => (dispatch) => {
   return api.writeTextResource(resource, value, (response) => {
     // FIXME: handle errors
     dispatch(bufferSaveSuccess(resource, response.entity));
-    cb && cb();
+    if (cb) {
+      cb();
+    }
   });
 };
 
@@ -175,7 +235,9 @@ export const resourceDelete = (api, resource, cb) => (dispatch) => {
   return api.deleteResource(resource, (response) => {
     // FIXME: handle errors
     dispatch(resourceDeleteSuccess(resource, response.entity));
-    cb && cb();
+    if (cb) {
+      cb();
+    }
   });
 };
 
@@ -202,6 +264,8 @@ export const directoryCreate = (api, sibling, name, cb) => (dispatch) => {
   return api.createFolder(sibling, name, (response) => {
     // handle errors?
     dispatch(directoryCreateSuccess(response.entity));
-    cb && cb();
+    if (cb) {
+      cb();
+    }
   });
 };

--- a/app/src/model/edit-reducers.js
+++ b/app/src/model/edit-reducers.js
@@ -69,6 +69,160 @@ const initialEditState = {
   expandedNodes: new Set(),
 };
 
+// IDEA: might be cool if this copied 'template.lua' as a starting point
+const handleScriptNew = (action, state) => {
+  const category = action.category || 'scripts';
+  const categoryIndex = rootCategoryIndex(state.rootNodes, category);
+
+  // assume script will be placed at the top of the hierarchy (by default)
+  let siblings = childrenOfRoot(state.rootNodes, categoryIndex);
+
+  const childPath = keyPathForResource(state.rootNodes, action.siblingResource);
+  if (childPath) {
+    // a sibling exists, use that level of hierarchy for name computation
+    const siblingPath = childPath.pop();
+    siblings = state.rootNodes.getIn(siblingPath);
+  }
+
+  const newName = generateNodeName(siblings, action.name || 'untitled.lua');
+  const newResource = siblingScriptResourceForName(newName, action.siblingResource, category);
+  const newBuffer = new Map({
+    modified: true,
+    value: action.value || '',
+    contentType: 'text/utf-8',
+  });
+
+  const newNode = virtualNode(newName, newResource);
+  const newRootNodes =
+    spliceFileInfo(state.rootNodes, newNode, action.siblingResource, categoryIndex);
+
+  return {
+    ...state,
+    rootNodes: newRootNodes,
+    activeBuffer: newResource,
+    buffers: state.buffers.set(newResource, newBuffer),
+  };
+};
+
+const handleBufferChange = (action, state) => {
+  if (action.resource === undefined) {
+    console.log('implicitly creating new script');
+    return handleScriptNew(scriptNew(undefined, action.value), state);
+  }
+
+  const buffer = state.buffers.get(action.resource);
+  if (buffer === undefined) {
+    console.log('ignoring change for missing buffer (possibly deleted):', action.resource);
+    return state;
+  }
+
+  // FIXME: super janky hack to prevent marking binary buffers dirty, this needs to be removed when
+  // proper alt ui is in place for the editor when binary files are selected
+  if (!buffer.get('contentType').includes('text')) {
+    console.log('ignoring buffer change for binary buffer');
+    return state;
+  }
+
+  const modified = buffer.get('modified') || buffer.get('value') !== action.value; // FIXME: inefficient?
+  const changes = new Map({
+    value: action.value,
+    modified,
+    contentType: buffer.get('contentType'),
+  });
+  return { ...state, buffers: state.buffers.set(action.resource, buffer.merge(changes)) };
+};
+
+const handleRootList = (action, state) => {
+  // FIXME: change the virtualNode resource to be the api path
+  let rootNode = virtualNode(action.name, '/', fromJS(action.value.entries));
+
+  const existingRootIndex = state.rootNodes.findIndex(n => n.get('name') === action.name);
+  if (existingRootIndex > 0) {
+    const virtuals = collectVirtualNodes(state.rootNodes.getIn([existingRootIndex, 'children']));
+    const rootChildren = rootNode.get('children');
+    rootNode = rootNode.set('children', spliceNodes(rootChildren, virtuals));
+  }
+
+  let rootNodes;
+  if (existingRootIndex > 0) {
+    rootNodes = state.rootNodes.set(existingRootIndex, rootNode);
+  } else {
+    rootNodes = state.rootNodes.push(rootNode);
+  }
+
+  return { ...state, rootNodes };
+};
+
+const handleResourceDeleteSuccess = (action, state) => {
+  console.log('in handleResourceDelete()', action);
+  const childPath = keyPathForResource(state.rootNodes, action.resource);
+  const newRootNodes = state.rootNodes.removeIn(childPath);
+  const newActiveBuffer = state.activeBuffer === action.resource ? undefined : state.activeBuffer;
+
+  return {
+    ...state,
+    rootNodes: newRootNodes,
+    activeBuffer: newActiveBuffer,
+    buffers: state.buffers.delete(action.resource),
+  };
+};
+
+const handleScriptDuplicate = (action, state) => {
+  if (!action.resource) {
+    // can't duplicate without a resource
+    return state;
+  }
+
+  const sourceNode = nodeForResource(state.rootNodes, action.resource);
+  if (!sourceNode) {
+    console.log('cannot find existing resource to duplicate');
+    return state;
+  }
+
+  const sourceBuffer = state.buffers.get(action.resource);
+  const newAction = scriptNew(action.resource, sourceBuffer.get('value'), sourceNode.get('name'));
+
+  return handleScriptNew(newAction, state);
+};
+
+const handleScriptNewFolderSuccess = (action, state) => state;
+
+const handleResourceRenameSuccess = (action, state) => {
+  console.log('rename success: ', action);
+
+  let newResource = action.newResource;
+  if (!newResource) {
+    // assume this is virtual; fabricate new url
+    newResource = siblingScriptResourceForName(action.newName, action.resource);
+    console.log(action.resource, ' => ', newResource);
+  }
+
+  const oldNode = nodeForResource(state.rootNodes, action.resource);
+  const newNode = oldNode.set('url', newResource).set('name', action.newName);
+
+  const keyPath = keyPathForResource(state.rootNodes, action.resource);
+  let rootNodes = state.rootNodes.setIn(keyPath, newNode);
+
+  // sort parent dir of node
+  const dirPath = keyPathParent(keyPath);
+
+  rootNodes = sortDir(rootNodes, dirPath);
+
+  // update active buffer if pointing at the renamed resource
+  const activeBuffer = state.activeBuffer === action.resource ? newResource : state.activeBuffer;
+
+  // buffers are keyed by resource, modify that too
+  const buffers =
+    state.buffers.set(newResource, state.buffers.get(action.resource)).delete(action.resource);
+
+  return {
+    ...state,
+    activeBuffer,
+    rootNodes,
+    buffers,
+  };
+};
+
 const edit = (state = initialEditState, action) => {
   switch (action.type) {
     case ROOT_LIST_SUCCESS:
@@ -138,158 +292,6 @@ const edit = (state = initialEditState, action) => {
     default:
       return state;
   }
-};
-
-
-const handleBufferChange = (action, state) => {
-  if (action.resource === undefined) {
-    console.log('implicitly creating new script');
-    return handleScriptNew(scriptNew(undefined, action.value), state);
-  }
-
-  const buffer = state.buffers.get(action.resource);
-  if (buffer === undefined) {
-    console.log('ignoring change for missing buffer (possibly deleted):', action.resource);
-    return state;
-  }
-
-  // FIXME: super janky hack to prevent marking binary buffers dirty, this needs to be removed when proper alt ui is in place for the editor when binary files are selected
-  if (!buffer.get('contentType').includes('text')) {
-    console.log('ignoring buffer change for binary buffer');
-    return state;
-  }
-
-  const modified = buffer.get('modified') || buffer.get('value') !== action.value; // FIXME: inefficient?
-  const changes = new Map({
-    value: action.value,
-    modified,
-    contentType: buffer.get('contentType'),
-  });
-  return { ...state, buffers: state.buffers.set(action.resource, buffer.merge(changes)) };
-};
-
-const handleRootList = (action, state) => {
-  // FIXME: change the virtualNode resource to be the api path
-  let rootNode = virtualNode(action.name, '/', fromJS(action.value.entries));
-
-  const existingRootIndex = state.rootNodes.findIndex(n => n.get('name') === action.name);
-  if (existingRootIndex > 0) {
-    const virtuals = collectVirtualNodes(state.rootNodes.getIn([existingRootIndex, 'children']));
-    const rootChildren = rootNode.get('children');
-    rootNode = rootNode.set('children', spliceNodes(rootChildren, virtuals));
-  }
-
-  let rootNodes;
-  if (existingRootIndex > 0) {
-    rootNodes = state.rootNodes.set(existingRootIndex, rootNode);
-  } else {
-    rootNodes = state.rootNodes.push(rootNode);
-  }
-
-  return { ...state, rootNodes };
-};
-
-// IDEA: might be cool if this copied 'template.lua' as a starting point
-const handleScriptNew = (action, state) => {
-  const category = action.category || 'scripts';
-  const categoryIndex = rootCategoryIndex(state.rootNodes, category);
-
-  // assume script will be placed at the top of the hierarchy (by default)
-  let siblings = childrenOfRoot(state.rootNodes, categoryIndex);
-
-  const childPath = keyPathForResource(state.rootNodes, action.siblingResource);
-  if (childPath) {
-    // a sibling exists, use that level of hierarchy for name computation
-    const siblingPath = childPath.pop();
-    siblings = state.rootNodes.getIn(siblingPath);
-  }
-
-  const newName = generateNodeName(siblings, action.name || 'untitled.lua');
-  const newResource = siblingScriptResourceForName(newName, action.siblingResource, category);
-  const newBuffer = new Map({
-    modified: true,
-    value: action.value || '',
-    contentType: 'text/utf-8',
-  });
-
-  const newNode = virtualNode(newName, newResource);
-  const newRootNodes = spliceFileInfo(state.rootNodes, newNode, action.siblingResource, categoryIndex);
-
-  return {
-    ...state,
-    rootNodes: newRootNodes,
-    activeBuffer: newResource,
-    buffers: state.buffers.set(newResource, newBuffer),
-  };
-};
-
-const handleResourceDeleteSuccess = (action, state) => {
-  console.log('in handleResourceDelete()', action);
-  const childPath = keyPathForResource(state.rootNodes, action.resource);
-  const newRootNodes = state.rootNodes.removeIn(childPath);
-  const newActiveBuffer = state.activeBuffer === action.resource ? undefined : state.activeBuffer;
-
-  return {
-    ...state,
-    rootNodes: newRootNodes,
-    activeBuffer: newActiveBuffer,
-    buffers: state.buffers.delete(action.resource),
-  };
-};
-
-const handleScriptDuplicate = (action, state) => {
-  if (!action.resource) {
-    // can't duplicate without a resource
-    return state;
-  }
-
-  const sourceNode = nodeForResource(state.rootNodes, action.resource);
-  if (!sourceNode) {
-    console.log('cannot find existing resource to duplicate');
-    return state;
-  }
-
-  const sourceBuffer = state.buffers.get(action.resource);
-  const newAction = scriptNew(action.resource, sourceBuffer.get('value'), sourceNode.get('name'));
-
-  return handleScriptNew(newAction, state);
-};
-
-const handleScriptNewFolderSuccess = (action, state) => state;
-
-const handleResourceRenameSuccess = (action, state) => {
-  console.log('rename success: ', action);
-
-  let newResource = action.newResource;
-  if (!newResource) {
-    // assume this is virtual; fabricate new url
-    newResource = siblingScriptResourceForName(action.newName, action.resource);
-    console.log(action.resource, ' => ', newResource);
-  }
-
-  const oldNode = nodeForResource(state.rootNodes, action.resource);
-  const newNode = oldNode.set('url', newResource).set('name', action.newName);
-
-  const keyPath = keyPathForResource(state.rootNodes, action.resource);
-  let rootNodes = state.rootNodes.setIn(keyPath, newNode);
-
-  // sort parent dir of node
-  const dirPath = keyPathParent(keyPath);
-
-  rootNodes = sortDir(rootNodes, dirPath);
-
-  // update active buffer if pointing at the renamed resource
-  const activeBuffer = state.activeBuffer === action.resource ? newResource : state.activeBuffer;
-
-  // buffers are keyed by resource, modify that too
-  const buffers = state.buffers.set(newResource, state.buffers.get(action.resource)).delete(action.resource);
-
-  return {
-    ...state,
-    activeBuffer,
-    rootNodes,
-    buffers,
-  };
 };
 
 export default edit;

--- a/app/src/model/edit-reducers.test.js
+++ b/app/src/model/edit-reducers.test.js
@@ -1,8 +1,7 @@
 // import rewire from 'rewire';
-import scripts from './edit-reducers';
-import { virtualRoot } from './listing';
-
 import { List, Map, Set } from 'immutable';
+
+import scripts from './edit-reducers';
 
 it('initial state should have empty list', () => {
   const state = scripts(undefined, { type: '@@INIT' });

--- a/app/src/model/listing.test.js
+++ b/app/src/model/listing.test.js
@@ -205,7 +205,8 @@ it('splice nodes works on all levels', () => {
         },
       ],
     },
-    // commenting this out since it complicates producing the r0 result since insertIn isn't a provided method and splicing sorts the listing
+    // commenting this out since it complicates producing the r0 result since insertIn isn't a
+    // provided method and splicing sorts the listing
     // { name: "untitled.lua", url: "/untitled.lua", virtual: true },
   ]));
 

--- a/app/src/model/repl-actions.js
+++ b/app/src/model/repl-actions.js
@@ -21,13 +21,27 @@ export const REPL_CLEAR = 'REPL_CLEAR';
 
 export const replEndpointsRequest = () => ({ type: REPL_ENDPOINTS_REQUEST });
 
-export const replEndpointsSuccess = endpoints => ({ type: REPL_ENDPOINTS_SUCCESS, endpoints });
+export const replEndpointsSuccess = endpoints => ({
+  type: REPL_ENDPOINTS_SUCCESS,
+  endpoints,
+});
 
-export const replEndpointsFailure = error => ({ type: REPL_ENDPOINTS_FAILURE, error });
+export const replEndpointsFailure = error => ({
+  type: REPL_ENDPOINTS_FAILURE,
+  error,
+});
 
-export const replConnectDial = (component, endpoint) => ({ type: REPL_CONNECT_DIAL, component, endpoint });
+export const replConnectDial = (component, endpoint) => ({
+  type: REPL_CONNECT_DIAL,
+  component,
+  endpoint,
+});
 
-export const replConnectSuccess = (component, socket) => ({ type: REPL_CONNECT_SUCCESS, component, socket });
+export const replConnectSuccess = (component, socket) => ({
+  type: REPL_CONNECT_SUCCESS,
+  component,
+  socket,
+});
 
 export const replConnectFailure = (component, error) =>
 // console.log(error);
@@ -63,13 +77,13 @@ export const replEndpoints = (api, cb) => (dispatch) => {
 export const replConnect = (component, endpoint) => (dispatch) => {
   dispatch(replConnectDial(component, endpoint));
   const socket = new WebSocket(endpoint, ['bus.sp.nanomsg.org']);
-  socket.onopen = (event) => {
+  socket.onopen = (_event) => {
     dispatch(replConnectSuccess(component, socket));
   };
   socket.onerror = (error) => {
     dispatch(replConnectFailure(component, error));
   };
-  socket.onclose = (event) => {
+  socket.onclose = (_event) => {
     dispatch(replConnectClose(component));
   };
   socket.onmessage = (event) => {

--- a/app/src/model/repl-reducers.js
+++ b/app/src/model/repl-reducers.js
@@ -41,11 +41,22 @@ const initialReplState = {
   history: new Map(),
 };
 
+
+/* eslint-disable no-param-reassign */
+const outputAppend = (buffer, limit, line) => {
+  buffer = buffer.push(line);
+  if (buffer.size > limit) {
+    buffer = buffer.shift();
+  }
+  return buffer;
+};
+/* eslint-enable no-param-reassign */
+
 const repl = (state = initialReplState, action) => {
   const conn = state.connections.get(action.component);
-  let changes,
-    history,
-    buffer;
+  let changes;
+  let history;
+  let buffer;
 
   switch (action.type) {
     case REPL_ENDPOINTS_SUCCESS:
@@ -54,36 +65,43 @@ const repl = (state = initialReplState, action) => {
 
     case REPL_CONNECT_DIAL:
       console.log('Connecting to [', action.component, '] ', action.endpoint);
-      const details = new Map({
-        socket: undefined,
-        error: undefined,
-      });
-      return { ...state, connections: state.connections.set(action.component, details) };
+      const details = new Map({ socket: undefined, error: undefined });
+      return {
+        ...state,
+        connections: state.connections.set(action.component, details),
+      };
 
     case REPL_CONNECT_FAILURE:
       // let conn = state.connections.get(action.component);
-      changes = new Map({
-        socket: undefined, // ensure this goes away
-        error: action.error,
-      });
-      return { ...state, connections: state.connections.set(action.component, conn.merge(changes)) };
+      changes = new Map({ socket: undefined, error: action.error }); // ensure this goes away
+      return {
+        ...state,
+        connections: state.connections.set(
+          action.component,
+          conn.merge(changes),
+        ),
+      };
 
     case REPL_CONNECT_CLOSE:
       // let conn = state.connections.get(action.component);
-      changes = new Map({
-        socket: undefined,
-        error: undefined,
-      });
-      return { ...state, connections: state.connections.set(action.component, conn.merge(changes)) };
+      changes = new Map({ socket: undefined, error: undefined });
+      return {
+        ...state,
+        connections: state.connections.set(
+          action.component,
+          conn.merge(changes),
+        ),
+      };
 
     case REPL_CONNECT_SUCCESS:
       // let conn = state.connections.get(action.component);
-      changes = new Map({
-        socket: action.socket,
-      });
+      changes = new Map({ socket: action.socket });
       return {
         ...state,
-        connections: state.connections.set(action.component, conn.merge(changes)),
+        connections: state.connections.set(
+          action.component,
+          conn.merge(changes),
+        ),
         buffers: state.buffers.set(action.component, new List()),
         history: state.history.set(action.component, new List()),
       };
@@ -93,15 +111,17 @@ const repl = (state = initialReplState, action) => {
       action.data.split('\n').forEach((line) => {
         buffer = outputAppend(buffer, state.scrollbackLimit, line);
       });
-      return {
-        ...state,
-        buffers: state.buffers.set(action.component, buffer),
-      };
+      return { ...state, buffers: state.buffers.set(action.component, buffer) };
 
     case REPL_SEND:
       const socket = conn.get('socket');
       if (!socket) {
-        console.log("No socket; can't send", action.value, 'to', action.component);
+        console.log(
+          "No socket; can't send",
+          action.value,
+          'to',
+          action.component,
+        );
         return state;
       }
       socket.send(`${action.value}\n`);
@@ -128,14 +148,6 @@ const repl = (state = initialReplState, action) => {
     default:
       return state;
   }
-};
-
-const outputAppend = (buffer, limit, line) => {
-  buffer = buffer.push(line);
-  if (buffer.size > limit) {
-    buffer = buffer.shift();
-  }
-  return buffer;
 };
 
 export default repl;

--- a/app/src/model/ui-reducers.js
+++ b/app/src/model/ui-reducers.js
@@ -24,6 +24,19 @@ const initialState = {
   replMinHeight: 100,
 };
 
+const handleToggleComponent = (state, action) => {
+  switch (action.name) {
+    case SIDEBAR_COMPONENT:
+      return { ...state, sidebarHidden: !state.sidebarHidden };
+
+    case REPL_COMPONENT:
+      return { ...state, replHidden: !state.replHidden };
+
+    default:
+      return state;
+  }
+};
+
 const ui = (state = initialState, action) => {
   switch (action.type) {
     case TOGGLE_COMPONENT:
@@ -34,19 +47,6 @@ const ui = (state = initialState, action) => {
 
     case REPL_SIZE:
       return { ...state, replHeight: action.height };
-
-    default:
-      return state;
-  }
-};
-
-const handleToggleComponent = (state, action) => {
-  switch (action.name) {
-    case SIDEBAR_COMPONENT:
-      return { ...state, sidebarHidden: !state.sidebarHidden };
-
-    case REPL_COMPONENT:
-      return { ...state, replHidden: !state.replHidden };
 
     default:
       return state;

--- a/app/src/repl-activity.js
+++ b/app/src/repl-activity.js
@@ -9,183 +9,182 @@ import { ICONS } from './svg-icons';
 import './repl-activity.css';
 
 const tools = [
-    {
-        name: "clear",
-        tooltipMessage: "clear",
-        tooltipPosition: "left",
-        icon: ICONS['forbidden'], // FIXME: temp
-    }
+  {
+    name: 'clear',
+    tooltipMessage: 'clear',
+    tooltipPosition: 'left',
+    icon: ICONS.forbidden, // FIXME: temp
+  },
 ];
 
 // TODO: refactor this and EditTools into a common function
 const ReplTools = (props) => {
-    const items = props.tools.map(tool => {
-        return (
-            <IconButton
-                key={tool.name}
-                tooltipMessage={tool.tooltipMessage}
-                tooltipPosition={tool.tooltipPosition}
-                action={() => props.buttonAction(tool.name)}
-                icon={tool.icon}
-                color="#979797"       // FIXME:
-                size="24"           // FIXME:
-            />
-        );
-    });
+  const items = props.tools.map(tool => (
+    <IconButton
+      key={tool.name}
+      tooltipMessage={tool.tooltipMessage}
+      tooltipPosition={tool.tooltipPosition}
+      action={() => props.buttonAction(tool.name)}
+      icon={tool.icon}
+      color="#979797" // FIXME:
+      size="24"
+    />
+  ));
 
-    const style = { width: props.width, height: props.height };
-    return (
-        <ToolBar style={style}>
-            {items}
-        </ToolBar>
-    );
+  const style = { width: props.width, height: props.height };
+  return (
+    <ToolBar style={style}>
+      {items}
+    </ToolBar>
+  );
 };
 
 // TODO: refactor this into a generic message/action widget
 const ReplConnect = (props) => {
-    let { height, width } = props;
-    let style = { height, width };
+  const { height, width } = props;
+  const style = { height, width };
 
-    return (
-        <div className="repl-connect-container" style={style}>
-            <div className="repl-connect-content">
-                <span className="message">Not connected to </span>
-                <span className="component">{props.activeRepl}</span>
-                <IconButton
-                    action={() => props.connectAction(props.activeRepl)}
-                    tooltipMessage="refresh connection"
-                    tooltipPosition="top"
-                    icon={ICONS['loop2']}
-                    color="#979797"       // FIXME:
-                    size="24"           // FIXME:
-                />
-            </div>
-        </div>
-    )
-}
+  return (
+    <div className="repl-connect-container" style={style}>
+      <div className="repl-connect-content">
+        <span className="message">Not connected to </span>
+        <span className="component">{props.activeRepl}</span>
+        <IconButton
+          action={() => props.connectAction(props.activeRepl)}
+          tooltipMessage="refresh connection"
+          tooltipPosition="top"
+          icon={ICONS.loop2}
+          color="#979797" // FIXME:
+          size="24"
+        />
+      </div>
+    </div>
+  );
+};
 
 const ReplSwitcherTab = (props) => {
-    let className = cx("repl-switcher-tab", {"noselect": true}, {"repl-active-tab": props.isActive});
-    let tooltipMessage = `show ${props.name} repl`; 
-    return (
-        <div>
-            <button 
-                className={className}
-                key={props.name}
-                onClick={props.onClick}
-                data-tip={tooltipMessage}
-                data-for={props.name}>
-                {props.name}
-            </button>
-            <ReactTooltip id={props.name} effect="solid" className="customTooltip" delayShow={1000} delayHide={500} place="top"></ReactTooltip>
-        </div>
-    );
-}
+  const className = cx('repl-switcher-tab', { noselect: true }, { 'repl-active-tab': props.isActive });
+  const tooltipMessage = `show ${props.name} repl`;
+  return (
+    <div>
+      <button
+        className={className}
+        key={props.name}
+        onClick={props.onClick}
+        data-tip={tooltipMessage}
+        data-for={props.name}
+      >
+        {props.name}
+      </button>
+      <ReactTooltip id={props.name} effect="solid" className="customTooltip" delayShow={1000} delayHide={500} place="top" />
+    </div>
+  );
+};
 
 const ReplSwitcher = (props) => {
-    let { activeRepl, height, width } = props;
+  const { activeRepl, height, width } = props;
 
-    let switcherSize = {
-        width,
-        height: 30,
-    };
+  const switcherSize = {
+    width,
+    height: 30,
+  };
 
-    let tabs = props.endpoints.keySeq().map(k => {
-        let isActive = props.activeRepl === k;
-        return (
-            <ReplSwitcherTab 
-                name={k} 
-                isActive={isActive}
-                key={k}
-                onClick={() => { props.replSelect(k) }}
-            />
-        );
-    })
-
-
-    let contentSize = {
-        width,
-        height: height - switcherSize.height,
-    };
-
-    var replView;
-    if (props.isConnected(activeRepl)) {
-        replView = <Repl
-                        className="repl-container"
-                        {...contentSize}
-                        activeRepl={activeRepl}
-                        buffers={props.buffers}
-                        history={props.history}
-                        replSend={props.replSend}
-                    />
-    } else {
-        replView = <ReplConnect
-                        {...contentSize}
-                        activeRepl={activeRepl}
-                        connectAction={props.handleConnect}
-                    />
-    }
-
+  const tabs = props.endpoints.keySeq().map((k) => {
+    const isActive = props.activeRepl === k;
     return (
-        <div>
-            <div className="repl-switcher-tabs" style={switcherSize}>
-                {tabs}
-            </div>
-            {replView}
-        </div>
+      <ReplSwitcherTab
+        name={k}
+        isActive={isActive}
+        key={k}
+        onClick={() => { props.replSelect(k); }}
+      />
     );
-}
+  });
+
+
+  const contentSize = {
+    width,
+    height: height - switcherSize.height,
+  };
+
+  let replView;
+  if (props.isConnected(activeRepl)) {
+    replView = (<Repl
+      className="repl-container"
+      {...contentSize}
+      activeRepl={activeRepl}
+      buffers={props.buffers}
+      history={props.history}
+      replSend={props.replSend}
+    />);
+  } else {
+    replView = (<ReplConnect
+      {...contentSize}
+      activeRepl={activeRepl}
+      connectAction={props.handleConnect}
+    />);
+  }
+
+  return (
+    <div>
+      <div className="repl-switcher-tabs" style={switcherSize}>
+        {tabs}
+      </div>
+      {replView}
+    </div>
+  );
+};
 
 
 class ReplActivity extends Component {
     TOOLBAR_WIDTH = 50;
 
     handleToolInvoke = (name) => {
-        if (name === 'clear') {
-            this.props.replClear(this.props.activeRepl)
-        }
+      if (name === 'clear') {
+        this.props.replClear(this.props.activeRepl);
+      }
     }
 
     replSize() {
-        return {
-            width: this.props.width - this.TOOLBAR_WIDTH - 1,
-            height: this.props.height,
-        }
+      return {
+        width: this.props.width - this.TOOLBAR_WIDTH - 1,
+        height: this.props.height,
+      };
     }
 
     toolsSize() {
-        return {
-            width: this.TOOLBAR_WIDTH,
-            height: this.props.height,
-        };
+      return {
+        width: this.TOOLBAR_WIDTH,
+        height: this.props.height,
+      };
     }
 
     handleConnect = (component) => {
-        let endpoint = this.props.endpoints.get(component)
-        this.props.replConnect(component, endpoint)
+      const endpoint = this.props.endpoints.get(component);
+      this.props.replConnect(component, endpoint);
     }
 
     render() {
-        let containerClassName = cx("repl-activity-container", {"hidden": this.props.hidden},);
+      const containerClassName = cx('repl-activity-container', { hidden: this.props.hidden });
 
-        return (
-            <div className={containerClassName}>
-                <div className="repl-activity">
-                    <ReplSwitcher 
-                        {...this.props}
-                        {...this.replSize()}
-                        handleConnect={this.handleConnect}
-                    />
-                    <ReplTools
-                        className="repl-tools"
-                        {...this.toolsSize()}
-                        tools={tools}
-                        buttonAction={this.handleToolInvoke}
-                    />
-                </div>
-            </div>
-        );
+      return (
+        <div className={containerClassName}>
+          <div className="repl-activity">
+            <ReplSwitcher
+              {...this.props}
+              {...this.replSize()}
+              handleConnect={this.handleConnect}
+            />
+            <ReplTools
+              className="repl-tools"
+              {...this.toolsSize()}
+              tools={tools}
+              buttonAction={this.handleToolInvoke}
+            />
+          </div>
+        </div>
+      );
     }
-};
+}
 
 export default ReplActivity;

--- a/app/src/repl.js
+++ b/app/src/repl.js
@@ -3,136 +3,133 @@ import './repl.css';
 
 
 class ReplOutput extends Component {
-    constructor(props) {
-        super(props)
-        this.scrollAdjusted = false;
-    }
+  constructor(props) {
+    super(props);
+    this.scrollAdjusted = false;
+  }
 
-    componentDidUpdate() {
-        // FIXME: this always forces scrolling to the bottom
-        if (this.output) {
-            this.output.scrollTo(0, this.output.scrollHeight)
-        }
+  componentDidUpdate() {
+    // FIXME: this always forces scrolling to the bottom
+    if (this.output) {
+      this.output.scrollTo(0, this.output.scrollHeight);
     }
+  }
 
-    isScrolledBottom() {
-        if (!this.output) {
-            return false;
-        }
-        let top = this.output.scrollTop;
-        let totalHeight = this.output.offsetHeight;
-        let clientHeight = this.output.clientHeight;
-        let atBottom = totalHeight <= top + clientHeight;
-        console.log("top", top, "totalH", totalHeight, "clientH", clientHeight, "bottom", atBottom);
-        return atBottom;
+  isScrolledBottom() {
+    if (!this.output) {
+      return false;
     }
+    const top = this.output.scrollTop;
+    const totalHeight = this.output.offsetHeight;
+    const clientHeight = this.output.clientHeight;
+    const atBottom = totalHeight <= top + clientHeight;
+    console.log('top', top, 'totalH', totalHeight, 'clientH', clientHeight, 'bottom', atBottom);
+    return atBottom;
+  }
 
-    render() {
-        let lines = this.props.lines.map((l, key) =>
-            <div className="repl-line" key={key}>{l}</div>
-        )
-        
-        // this.isScrolledBottom()
-        return (
-            <div 
-                className="repl-output"
-                ref={elem => this.output = elem}
-            >
-                {lines}
-            </div>
-        )
-    };
+  render() {
+    const lines = this.props.lines.map((l, key) =>
+      <div className="repl-line" key={key}>{l}</div>);
+
+    // this.isScrolledBottom()
+    return (
+      <div
+        className="repl-output"
+        ref={elem => this.output = elem}
+      >
+        {lines}
+      </div>
+    );
+  }
 }
 
 class ReplInput extends Component {
-    constructor(props) {
-        super(props);
-        this.histroyIdx = 0;
-    }
+  constructor(props) {
+    super(props);
+    this.histroyIdx = 0;
+  }
 
     onKeyDown = (event) => {
-        var history;
+      let history;
 
-        switch (event.keyCode) {
-            case 13: // return
-                event.preventDefault();
-                this.props.sendCommand(this.input.value);
-                this.input.value = "";
-                this.historyIdx = 0;
-                break;
-            
-            case 38: // up arrow
-                event.preventDefault();
-                history = this.props.history
-                if (this.historyIdx < history.size) {
-                    this.input.value = history.get(this.historyIdx)
-                    this.historyIdx += 1;
-                }
-                break;
+      switch (event.keyCode) {
+        case 13: // return
+          event.preventDefault();
+          this.props.sendCommand(this.input.value);
+          this.input.value = '';
+          this.historyIdx = 0;
+          break;
 
-            case 40: // down arrow
-                event.preventDefault();
-                this.historyIdx -= 1;
-                if (this.historyIdx < 0) {
-                    this.historyIdx = 0;
-                    this.input.value = ""
-                }
-                else {
-                    this.input.value = this.props.history.get(this.historyIdx)
-                }
-                break;
-        
-            default:
-                break;
-        }
+        case 38: // up arrow
+          event.preventDefault();
+          history = this.props.history;
+          if (this.historyIdx < history.size) {
+            this.input.value = history.get(this.historyIdx);
+            this.historyIdx += 1;
+          }
+          break;
+
+        case 40: // down arrow
+          event.preventDefault();
+          this.historyIdx -= 1;
+          if (this.historyIdx < 0) {
+            this.historyIdx = 0;
+            this.input.value = '';
+          } else {
+            this.input.value = this.props.history.get(this.historyIdx);
+          }
+          break;
+
+        default:
+          break;
+      }
     }
 
     componentDidMount() {
-        this.input.focus()
+      this.input.focus();
     }
 
     render() {
-        return (
-            <div className="repl-input">
-                <span className="label">>></span>
-                <textarea 
-                    className="value"
-                    ref={(e) => { this.input = e }}
-                    onKeyDown={this.onKeyDown}
-                    autoFocus="true"
-                    spellCheck="false"
-                    rows={1}
-                />
-            </div>
-        )
+      return (
+        <div className="repl-input">
+          <span className="label">>></span>
+          <textarea
+            className="value"
+            ref={(e) => { this.input = e; }}
+            onKeyDown={this.onKeyDown}
+            autoFocus="true"
+            spellCheck="false"
+            rows={1}
+          />
+        </div>
+      );
     }
 }
 class Repl extends Component {
-
     sendCommand = (text) => {
-        this.props.replSend(this.props.activeRepl, text)
+      this.props.replSend(this.props.activeRepl, text);
     }
 
     render() {
-        let lines = this.props.buffers.get(this.props.activeRepl);
-        if (lines === undefined) {
-            lines = [];
-        }
-        let history = this.props.history.get(this.props.activeRepl);
-        const style = {
-            height: this.props.height,
-            width: this.props.width,
-        };
-        return (
-            <div className="repl" style={style}>
-                <ReplOutput lines={lines}/>
-                <ReplInput 
-                    sendCommand={this.sendCommand}
-                    history={history}
-                />
-            </div>
-        );
+      let lines = this.props.buffers.get(this.props.activeRepl);
+      if (lines === undefined) {
+        lines = [];
+      }
+      const history = this.props.history.get(this.props.activeRepl);
+      const style = {
+        height: this.props.height,
+        width: this.props.width,
+      };
+      return (
+        <div className="repl" style={style}>
+          <ReplOutput lines={lines} />
+          <ReplInput
+            sendCommand={this.sendCommand}
+            history={history}
+          />
+        </div>
+      );
     }
-};
+}
 
 export default Repl;

--- a/app/src/workspace.js
+++ b/app/src/workspace.js
@@ -3,97 +3,97 @@ import ReactModal from 'react-modal';
 import ActivityBar from './activity-bar';
 import './workspace.css';
 
-ReactModal.setAppElement('#root')
+ReactModal.setAppElement('#root');
 
 class Workspace extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            activityBarWidth: 50,
-            showModal: false,
-        };
-    }
+  constructor(props) {
+    super(props);
+    this.state = {
+      activityBarWidth: 50,
+      showModal: false,
+    };
+  }
 
-    componentWillMount() {
-        // MAINT: this is a bit odd here but we initiate the connections for the repl early so that any actions taken in the editor (or output from matron/crone) is captured even if the repl isn't being displayed
-       this.props.replEndpoints(this.props.api, (endpoints) => {
-           endpoints.forEach((endpoint, component) => {
-               this.props.replConnect(component, endpoint)
-           })
-       })
+  componentWillMount() {
+    // MAINT: this is a bit odd here but we initiate the connections for the repl early so that any
+    // actions taken in the editor (or output from matron/crone) is captured even if the repl isn't
+    // being displayed
+    this.props.replEndpoints(this.props.api, (endpoints) => {
+      endpoints.forEach((endpoint, component) => {
+        this.props.replConnect(component, endpoint);
+      });
+    });
 
-       // trigger initial read of top level scripts
-       this.props.scriptList(this.props.api)
-       this.props.dataList(this.props.api)
-       this.props.audioList(this.props.api)
-    }
+    // trigger initial read of top level scripts
+    this.props.scriptList(this.props.api);
+    this.props.dataList(this.props.api);
+    this.props.audioList(this.props.api);
+  }
 
-    activityBarSize() {
-        return {
-            width: this.state.activityBarWidth,
-            height: this.props.height,
-        };
-    }
+  activityBarSize() {
+    return {
+      width: this.state.activityBarWidth,
+      height: this.props.height,
+    };
+  }
 
-    activityViewSize() {
-        return {
-            width: this.props.width - this.state.activityBarWidth,
-            height: this.props.height,
-        };
-    }
+  activityViewSize() {
+    return {
+      width: this.props.width - this.state.activityBarWidth,
+      height: this.props.height,
+    };
+  }
 
     handleActivitySelection = (activity) => {
-        if (activity.selector === this.props.selected) {
-            this.props.toggleComponent(activity.toggle)
-        }
-        else {
-            this.props.activitySelect(activity.selector)
-        }
+      if (activity.selector === this.props.selected) {
+        this.props.toggleComponent(activity.toggle);
+      } else {
+        this.props.activitySelect(activity.selector);
+      }
     }
 
     handleShowModal = (content) => {
-        this.setState({
-            showModal: true,
-            modalContent: content,
-        })
+      this.setState({
+        showModal: true,
+        modalContent: content,
+      });
     }
 
     handleHideModal = () => {
-        this.setState({
-            showModal: false,
-            modalContent: undefined,
-        })
+      this.setState({
+        showModal: false,
+        modalContent: undefined,
+      });
     }
 
     render() {
-        const selectedActivity = this.props.activities.find(a => {
-            return this.props.selected === a.selector
-        });
-        const ActivityView = selectedActivity.view;
+      const selectedActivity = this.props.activities.find(a => this.props.selected === a.selector);
+      const ActivityView = selectedActivity.view;
 
-        return (
-            <div className="workspace">
-                <ActivityBar
-                    style={this.activityBarSize()}
-                    selected={this.props.selected}
-                    activities={this.props.activities}
-                    buttonAction={this.handleActivitySelection} />
-                <ActivityView
-                    {...this.activityViewSize()}
-                    showModal={this.handleShowModal}
-                    hideModal={this.handleHideModal}
-                    api={this.props.api}
-                />
-                <ReactModal
-                    isOpen={this.state.showModal}
-                    contentLabel={"something"}
-                    className="workspace-modal"
-                    overlayClassName="workspace-modal-overlay"
-                >
-                    {this.state.modalContent}
-                </ReactModal>
-            </div>
-        )
+      return (
+        <div className="workspace">
+          <ActivityBar
+            style={this.activityBarSize()}
+            selected={this.props.selected}
+            activities={this.props.activities}
+            buttonAction={this.handleActivitySelection}
+          />
+          <ActivityView
+            {...this.activityViewSize()}
+            showModal={this.handleShowModal}
+            hideModal={this.handleHideModal}
+            api={this.props.api}
+          />
+          <ReactModal
+            isOpen={this.state.showModal}
+            contentLabel="something"
+            className="workspace-modal"
+            overlayClassName="workspace-modal-overlay"
+          >
+            {this.state.modalContent}
+          </ReactModal>
+        </div>
+      );
     }
 }
 


### PR DESCRIPTION
Cleans up most remaining lint warnings, ignoring some in the `.eslintrc`.  I’ve opened a tracking issue (#55) to nudge us to revisit and reenable/rationalize disabled lints.  Once this lands, I’ll do some config work to make running prettier not contradictory.  After that, we can do a big formatting pass.

Most of these changes were trivial.  Of interest maybe are the holes I poked for specific globals (“document”, “window”, etc.) Also, the refinement to "no-unused-vars" which allows arguments prefixed with an `_` to go unused (handy in callbacks where the param is ignored).  The list of disabled rules is a bit long -- in many cases there are only one or two violations but the syntax to ignore in source is awkward.  It's also possibly nice to have all the rules to review listed in one place rather than having to grep around for them. Looking ahead, I look forward to hearing rationale around some of the ones I disabled.  The react ones are probably valuable, others such as “class-methods-use-this”  and possibly “prefer-destructuring” maybe less so.

Finally, I did not include my yarn.lock file since I don't know if it's sane.  I also don't know how to capture the `npm`-fu I had to do to get eslint happy w/ the experimental syntax.  Maybe @jlmitch5 can help me with that?

I'm _pretty sure_ this is what needs to happen:

```console
npm i babel-eslint
(   export PKG=eslint-config-airbnb;   npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG@latest"; )
```

Phew.  Sorry this is a lot.  It turned out to be more of a project than I expected.

On the bright side, the hard part should really be done. ☀️ 

@ngwese : I don't have a fully running setup so I couldn't verify that I didn't inadvertently break the repl or something.  Please keep an eye out for anything dumb I may have done.

Cheers!

