### PR TITLE
Add a searchbox to the Ace Editor component.

### DIFF
--- a/app/src/editor.js
+++ b/app/src/editor.js
@@ -3,6 +3,7 @@ import AceEditor from 'react-ace';
 
 import './editor.css';
 
+import 'brace/ext/searchbox';
 import 'brace/mode/lua';
 import 'brace/theme/dawn';
 


### PR DESCRIPTION
Adds a searchbox to the ace editor component.

Here's how it works.  **⌘F** then...

![searchbox](https://user-images.githubusercontent.com/67586/39899915-54076c0e-5473-11e8-8451-327652e81352.gif)

Not sure if this was considered already, but if not, worth a look!


/cc @ngwese @jlmitch5 

