### PR TITLE
keybinding for repl toggle

### DIFF
--- a/app/src/activities.js
+++ b/app/src/activities.js
@@ -16,7 +16,7 @@ const activities = [
   },
   {
     selector: 'editor',
-    tooltipMessage: 'toggle repl',
+    tooltipMessage: `toggle repl (${OS.metaKey()}E)`,
     tooltipPosition: 'right',
     icon: ICONS.terminal,
     toggle: REPL_COMPONENT,

--- a/app/src/edit-activity.js
+++ b/app/src/edit-activity.js
@@ -234,6 +234,7 @@ class EditActivity extends Component {
                     { ...this.editorSize() }
                     bufferName={activeBuffer}
                     toolInvoke={this.handleToolInvoke}
+                    replToggle={this.props.replToggle}
                     sidebarToggle={this.props.sidebarToggle}
                     value={code}
                     bufferChange={this.props.bufferChange}

--- a/app/src/editor.js
+++ b/app/src/editor.js
@@ -24,9 +24,6 @@ class Editor extends Component {
             useSoftTabs: true,
         });
 
-        // suppress the default print margin.
-        editor.setPrintMarginColumn(-1);
-
         /*
         if (this.refs.ace) {
             window.setTimeout(() => {
@@ -137,7 +134,12 @@ class Editor extends Component {
                     name: 'toggle sidebar',
                     bindKey: { win: "Ctrl-B", mac: "Command-B" },
                     exec: () => this.props.sidebarToggle(),
-                  },                
+                  },
+                  {
+                    name: 'toggle repl',
+                    bindKey: { win: "Ctrl-E", mac: "Command-E" },
+                    exec: () => this.props.replToggle(),
+                  }           
                 ]}
                 editorProps={{
                     $blockScrolling: Infinity,


### PR DESCRIPTION
Adds keybinding (⌘E) to toggle repl view.

![image](https://user-images.githubusercontent.com/67586/39950851-657999aa-5539-11e8-8fe3-a904cd414267.png)

Cleans up unneeded print margin suppression (done in editor properties now).

/cc @ngwese @jlmitch5 


