### PR TITLE
add a workspace key service

### DIFF
--- a/app/src/edit-activity.js
+++ b/app/src/edit-activity.js
@@ -5,6 +5,7 @@ import Editor from './editor';
 import ToolBar from './tool-bar';
 import IconButton from './icon-button';
 import { ICONS } from './svg-icons';
+import { commandService } from './services';
 import OS from './utils';
 
 import ReplActivity from './bound-repl-activity'
@@ -225,6 +226,17 @@ class EditActivity extends Component {
             t.disabled = !canEdit;
             return t;
         })
+
+        // TODO (pq): move this somewhere more appropriate.
+        commandService.registerCommand('toggle repl', () =>
+            this.props.replToggle())
+        commandService.registerCommand('toggle sidebar', () =>
+            this.props.sidebarToggle())
+        commandService.registerCommand('play', () =>
+            this.handleToolInvoke('play'))
+        commandService.registerCommand('save', () =>
+            this.handleToolInvoke('save'))
+        
         // TODO: switch editor based on buffer content type
         const editor = (
             <div className='editor-pane'>
@@ -233,9 +245,6 @@ class EditActivity extends Component {
                     ref={(component) => {this.editor = component;}}
                     { ...this.editorSize() }
                     bufferName={activeBuffer}
-                    toolInvoke={this.handleToolInvoke}
-                    replToggle={this.props.replToggle}
-                    sidebarToggle={this.props.sidebarToggle}
                     value={code}
                     bufferChange={this.props.bufferChange}
                 />

--- a/app/src/editor.js
+++ b/app/src/editor.js
@@ -24,6 +24,8 @@ class Editor extends Component {
             useSoftTabs: true,
         });
 
+        // TODO (pq): remove keys bound in the key service to ensure no interference.
+
         /*
         if (this.refs.ace) {
             window.setTimeout(() => {
@@ -119,28 +121,6 @@ class Editor extends Component {
                 onLoad={this.onLoad}
                 onChange={this.onChange}
                 showPrintMargin={false}
-                commands={[
-                  {  
-                    name: 'save',
-                    bindKey: { win: "Ctrl-S", mac: "Command-S" },
-                    exec: () => this.props.toolInvoke('save'),
-                  },
-                  {
-                    name: 'play',
-                    bindKey: { win: "Ctrl-P", mac: "Command-P" },
-                    exec: () => this.props.toolInvoke('play'),
-                  },
-                  {
-                    name: 'toggle sidebar',
-                    bindKey: { win: "Ctrl-B", mac: "Command-B" },
-                    exec: () => this.props.sidebarToggle(),
-                  },
-                  {
-                    name: 'toggle repl',
-                    bindKey: { win: "Ctrl-E", mac: "Command-E" },
-                    exec: () => this.props.replToggle(),
-                  }           
-                ]}
                 editorProps={{
                     $blockScrolling: Infinity,
                     $newLineMode: "unix",

--- a/app/src/services.js
+++ b/app/src/services.js
@@ -1,0 +1,100 @@
+import OS from './utils';
+
+const Modifier = {
+  CMD: 1,
+  win: {
+    1: {
+      name: 'Ctrl',
+      label: 'ctrl+',
+      matches: e => e.ctrlKey,
+    },
+  },
+  mac: {
+    1: {
+      name: 'Command',
+      label: '⌘',
+      matches: e => e.metaKey,
+    },
+  },
+};
+
+class KeyStroke {
+  constructor(modifier, key) {
+    this.modifier = modifier;
+    this.key = key;
+  }
+
+  get win() {
+    return Modifier.win[this.modifier];
+  }
+
+  get mac() {
+    return Modifier.mac[this.modifier];
+  }
+
+  get osModifier() {
+    return OS.isMac ? this.mac : this.win;
+  }
+
+  matches(event) {
+    if (!this.osModifier.matches(event)) {
+      return false;
+    }
+    const key = String.fromCharCode(event.keyCode);
+    return key === this.key;
+  }
+}
+
+class KeyBinding {
+  constructor(keystroke, commandId) {
+    this.keystroke = keystroke;
+    this.commandId = commandId;
+  }
+}
+
+class CommandService {
+  constructor() {
+    this.commands = new Map();
+  }
+  registerCommand(name, cmd) {
+    this.commands.set(name, cmd);
+  }
+}
+
+export const commandService = new CommandService();
+
+class KeyService {
+  constructor() {
+    this.bindings = [];
+  }
+
+  handleKey(event) {
+    // parse and dispatch
+    const cmd = this.findCommand(event);
+    if (cmd != null) {
+      cmd();
+      // cancels.
+      return false;
+    }
+    return true;
+  }
+
+  findCommand(event) {
+    const binding = this.bindings.find(b => b.keystroke.matches(event));
+    if (binding != null) {
+      const id = binding.commandId;
+      return commandService.commands.get(id);
+    }
+    return null;
+  }
+}
+
+export const keyService = new KeyService();
+
+keyService.bindings = [
+  // TODO (pq): consider an enum (or consts) for command names
+  new KeyBinding(new KeyStroke(Modifier.CMD, 'P'), 'play'),
+  new KeyBinding(new KeyStroke(Modifier.CMD, 'S'), 'save'),
+  new KeyBinding(new KeyStroke(Modifier.CMD, 'E'), 'toggle repl'),
+  new KeyBinding(new KeyStroke(Modifier.CMD, 'B'), 'toggle sidebar'),
+];

--- a/app/src/workspace.js
+++ b/app/src/workspace.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import ReactModal from 'react-modal';
 import ActivityBar from './activity-bar';
+import { keyService } from './services';
 import './workspace.css';
 
 ReactModal.setAppElement('#root')
@@ -26,6 +27,9 @@ class Workspace extends Component {
        this.props.scriptList(this.props.api)
        this.props.dataList(this.props.api)
        this.props.audioList(this.props.api)
+
+       // direct key events to the key service for handling
+       document.onkeydown= (event) => keyService.handleKey(event)
     }
 
     activityBarSize() {


### PR DESCRIPTION
More work towards #26.

* introduces two service classes (`CommandService` and `KeyService`) to encapsulate command and binding registrations and dispatch (respectively)
* moves key handling to an event listener at the workspace level; this
  * ensures bindings are uniformly handled across components and 
  * stops the propagation of state accessors into `props` to thread access down to the editor
* removes editor-specific keybinding registrations

The classes may get a bit restructured but the basic idea feels reasonable (and WAY better than what I had in there before).  Needless to say input welcome.  TODOs include finding the right place to do the command registration, unifying tooltips, adding consts or something to reflect how command ids should be considered const and some keybinding deregistration in the editor in case of collisions.

/cc @ngwese @jlmitch5  