### PR TITLE
tweak message container message font size

### DIFF
--- a/app/src/modal-content.css
+++ b/app/src/modal-content.css
@@ -8,6 +8,7 @@
 
 .modal-content > .message-container > .message {
     font-weight: bolder;
+    font-size: 18px;
 }
 
 .modal-content > .message-container > .supporting {


### PR DESCRIPTION
Small tweak up for consideration.  

Ups the size of the message text, setting it apart from the placeholder text a bit more.

Before:

![image](https://user-images.githubusercontent.com/67586/39975136-a45021c2-56e1-11e8-912a-a5ddd655d7d6.png)

After:

![image](https://user-images.githubusercontent.com/67586/39975119-904e87c2-56e1-11e8-9fe3-ec53bef198fa.png)

_I know there are a bunch of styling changes in flight so if this conflicts/contradicts or isn't compatible with where you're headed, no worries!_ 👍 

/cc @ngwese 