### PR TITLE
repl label and input value style tweaks

### DIFF
--- a/app/src/repl.css
+++ b/app/src/repl.css
@@ -64,8 +64,9 @@
 .repl-input > .label {
     flex: 0 0 auto;
     /* height: 40px; */
-    padding: 5px;
+    padding: 0px 5px 5px 5px;
     color:  rgb(117, 117, 117);
+    font-size: 20px;
 }
 
 .repl-input > .value {
@@ -80,6 +81,7 @@
     -moz-box-shadow: none;
     box-shadow: none;
     font-size: 16px;
+    font-family: monospace;
     /* text-align: center; */
 
 }


### PR DESCRIPTION
repl CSS tweaks

* bump label size and remove padding on top for better alignment
* changed repl input  font to be monospace to look more like a terminal

Before:

![image](https://user-images.githubusercontent.com/67586/40012524-d01db58e-575f-11e8-81b2-f93fadc2070a.png)

After:

![image](https://user-images.githubusercontent.com/67586/40012531-d336b090-575f-11e8-9167-f480a89b4105.png)

/cc @ngwese @jlmitch5 


