### PR TITLE
prevent swipe gesture back/forward navigation

### DIFF
--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -1,6 +1,8 @@
 {
     "extends": "airbnb",
     "rules": {
+        "arrow-parens": "off",
+        "function-paren-newline": "off",
         "react/jsx-filename-extension": [1, {"extensions": [".js"]}]
     },
     "globals": {

--- a/app/src/workspace.js
+++ b/app/src/workspace.js
@@ -32,6 +32,25 @@ class Workspace extends Component {
        // register workspace commands
        this.registerCommands()
 
+       // prevent accidental navigation out of maiden via swipe gestures
+       var preventNavigation = function (e) {
+         var delta = e.deltaX || e.wheelDeltaX;
+         if (!delta) {
+             return;
+         }
+
+         // adjust for safari
+         if (window.WebKitMediaKeyError) {
+             delta *= -1;
+         }
+
+         const elem = document.body;
+         if (((elem.scrollLeft + elem.offsetWidth) === elem.scrollWidth && delta > 0) || (elem.scrollLeft === 0 && delta < 0)) {
+             e.preventDefault();
+         }
+       };
+       document.addEventListener('mousewheel', preventNavigation);
+
        // direct key events to the key service for handling
        document.onkeydown= (event) => keyService.handleKey(event)
     }


### PR DESCRIPTION
prevents accidental navigation out of maiden with swipe gestures.

which is to say, this shouldn't happen any more on an unintended swipe:

![scroll_nav](https://user-images.githubusercontent.com/67586/40071518-dac045ee-5825-11e8-85c3-78eb13798843.gif)

tested on mac os chrome and safari 

_(notice the `window.WebKitMediaKeyError` check --- @jlmitch5 : happy to hear if there's a better approach to this check? 👍 )_

/cc @ngwese @jlmitch5 
