### PR TITLE
init editor.json onload

### DIFF
--- a/app/src/editor.js
+++ b/app/src/editor.js
@@ -41,7 +41,7 @@ class Editor extends Component {
             this.setOptions(this.props.editorOptions, this.editor);
         }
 
-        this.props.editorConfig(this.props.api, 'api/v1/data/editor.json');
+        this.props.editorConfig(this.props.api, '/api/v1/data/editor.json');
 
         // the 'showSettingsMenu' from 'brace/ext/settings_menu' exposes a host of themes and
         // modes we don't want to support (or require unconditionally).


### PR DESCRIPTION
the conditional was written thinking the initial state of the config would be undefined, this makes the config load