### PR TITLE
naive file-mode auto-detection

### DIFF
--- a/app/src/editor.js
+++ b/app/src/editor.js
@@ -137,10 +137,14 @@ class Editor extends Component {
         const width = `${this.props.width}px`;
         const height = `${this.props.height}px`;
 
+        // fall back to a simple text mode for non-lua files.
+        const fileName = this.props.bufferName;
+        const mode = fileName && fileName.endsWith(".lua") ? "lua" : "text";
+
         return (
             <AceEditor
                 ref="ace"
-                mode="lua"
+                mode={mode}
                 theme="dawn"
                 width={width}
                 height={height}


### PR DESCRIPTION
follow-up from #50, a quick and dirty file-mode check.

gives `.lua` files a the `"lua"` mode

![image](https://user-images.githubusercontent.com/67586/40334981-1df303c0-5d16-11e8-91ea-22cca420ecd7.png)

and for others falls back on `"text"`

![image](https://user-images.githubusercontent.com/67586/40334978-1ac88a76-5d16-11e8-92ad-012d172e1df6.png)

/cc @ngwese @jlmitch5 


