### PR TITLE
lua snippet and basic auto complete support

### DIFF
--- a/app/src/editor.js
+++ b/app/src/editor.js
@@ -4,8 +4,10 @@ import api from './api';
 
 import './editor.css';
 
+import 'brace/ext/language_tools';
 import 'brace/ext/searchbox';
 import 'brace/mode/lua';
+import 'brace/snippets/lua'
 import 'brace/theme/dawn';
 import 'brace/keybinding/vim';
 import 'brace/keybinding/emacs';
@@ -154,6 +156,8 @@ class Editor extends Component {
                 onLoad={this.onLoad}
                 onChange={this.onChange}
                 showPrintMargin={false}
+                enableBasicAutocompletion={true}
+                enableSnippets={true}
                 editorProps={{
                     $blockScrolling: Infinity,
                     $newLineMode: "unix",


### PR DESCRIPTION

snippets and completions are invoked w/ **⌘.**  (or non-mac: **ctrl+.**).

![snips](https://user-images.githubusercontent.com/67586/40878612-47bd5030-6648-11e8-930e-52bf677aa203.gif)

i’d like to experiment with some custom snippets and completions but the basics already add value IMO.  down the road we could consider enabling live completion (e.g., not behind **⌘.**) but that’s disruptive enough that it should be opted-in via an editor config.

/cc @ngwese 

