### PR TITLE
linkify repl output

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -10,6 +10,7 @@
     "react": "^16.2.0",
     "react-ace": "^5.9.0",
     "react-dom": "^16.2.0",
+    "react-linkify": "^0.2.2",
     "react-modal": "^3.2.1",
     "react-redux": "^5.0.6",
     "react-scripts": "1.0.17",

--- a/app/src/repl.js
+++ b/app/src/repl.js
@@ -1,3 +1,4 @@
+import Linkify from 'react-linkify';
 import React, { Component } from 'react';
 import './repl.css';
 
@@ -27,9 +28,13 @@ class ReplOutput extends Component {
         return atBottom;
     }
 
+    linkify(l) {
+        return <Linkify properties={{target: '_blank'}}>{l}</Linkify>
+    }
+
     render() {
         let lines = this.props.lines.map((l, key) =>
-            <div className="repl-line" key={key}>{l}</div>
+            <div className="repl-line" key={key}>{this.linkify(l)}</div>
         )
         
         // this.isScrolledBottom()
@@ -41,7 +46,7 @@ class ReplOutput extends Component {
                 {lines}
             </div>
         )
-    };
+    }
 }
 
 class ReplInput extends Component {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -4074,6 +4074,12 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+linkify-it@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.0.3.tgz#d94a4648f9b1c179d64fa97291268bdb6ce9434f"
+  dependencies:
+    uc.micro "^1.0.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -5440,6 +5446,14 @@ react-error-overlay@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-3.0.0.tgz#c2bc8f4d91f1375b3dad6d75265d51cd5eeaf655"
 
+react-linkify@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/react-linkify/-/react-linkify-0.2.2.tgz#55b99b1cc7244446a0f9bdebbe13b2c30f789e65"
+  dependencies:
+    linkify-it "^2.0.3"
+    prop-types "^15.5.8"
+    tlds "^1.57.0"
+
 react-modal@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.2.1.tgz#fa8f76aed55b67c22dcf1a1c15b05c8d11f18afe"
@@ -6467,6 +6481,10 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+tlds@^1.57.0:
+  version "1.203.1"
+  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.203.1.tgz#4dc9b02f53de3315bc98b80665e13de3edfc1dfc"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -6541,6 +6559,10 @@ typedarray@^0.0.6:
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
+
+uc.micro@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.5.tgz#0c65f15f815aa08b560a61ce8b4db7ffc3f45376"
 
 uglify-js@3.3.x, uglify-js@^3.0.13:
   version "3.3.4"


### PR DESCRIPTION
linkifies repl outputs

![image](https://user-images.githubusercontent.com/67586/41124669-8b11026a-6a57-11e8-84b0-21eb801e1a9a.png)

note the use of the `_blank` target property to ensure we open in a fresh tab/page.  we'll want to be smarter about when to do that when we support routing #70.


/cc @ngwese @anthonybarsotti 