### PR TITLE
norns lua mode / editing improvements

### DIFF
--- a/app/src/editor.js
+++ b/app/src/editor.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import AceEditor from 'react-ace';
-import ace from 'brace';
 import 'brace/ext/language_tools';
 import 'brace/ext/searchbox';
 import 'brace/mode/lua';
@@ -13,7 +12,6 @@ import api from './api';
 import { editorService } from './services';
 
 import './editor.css';
-
 
 class Editor extends Component {
   constructor(props) {

--- a/app/src/editor.js
+++ b/app/src/editor.js
@@ -10,11 +10,10 @@ import 'brace/keybinding/vim';
 import 'brace/keybinding/emacs';
 
 import api from './api';
-import { getCompleter } from './services';
+import { editorService } from './services';
 
 import './editor.css';
 
-const langTools = ace.acequire('ace/ext/language_tools');
 
 class Editor extends Component {
   constructor(props) {
@@ -149,19 +148,13 @@ class Editor extends Component {
     const width = `${this.props.width}px`;
     const height = `${this.props.height}px`;
 
-    // fall back to a simple text mode for non-lua files.
-    const fileName = this.props.bufferName;
-    const mode = fileName && fileName.endsWith('.lua') ? 'lua' : 'text';
-
-    const completer = getCompleter(fileName);
-    if (completer) {
-      langTools.addCompleter(completer);
-    }
+    const mode = editorService.getMode(this.props.bufferName);
+    mode.onRender(this.editor);
 
     return (
       <AceEditor
         ref="ace"
-        mode={mode}
+        mode={mode.id}
         theme="dawn"
         width={width}
         height={height}

--- a/app/src/mode/lua.js
+++ b/app/src/mode/lua.js
@@ -44,10 +44,8 @@ const luaKeyWordsToAdd = [
 class NornsLuaRules extends window.ace.acequire('ace/mode/lua_highlight_rules').LuaHighlightRules {
   constructor() {
     super();
-    console.log(this.$keywordList);
     const filteredKeywords = this.$keywordList.filter(k => !includes(luaKeyWordsToFilter, k));
     this.$keywordList = filteredKeywords.concat(luaKeyWordsToAdd);
-    console.log(this.$keywordList);
   }
 }
 

--- a/app/src/mode/lua.js
+++ b/app/src/mode/lua.js
@@ -1,0 +1,59 @@
+import 'brace/mode/lua';
+import 'brace/mode/text';
+
+const includes = require('array-includes');
+
+const luaKeyWordsToFilter = [
+  // lua version incompatibilities.
+  //
+  // 5.2 => 5.3: https://www.lua.org/manual/5.3/manual.html#8
+  // deprecated:
+  'atan2',
+  'cosh',
+  'sinh',
+  'tanh',
+  'pow',
+  'frexp',
+  'ldexp',
+  // 5.1 => 5.2: http://www.lua.org/manual/5.2/manual.html#8
+  // deprecated/removed:
+  'module',
+  'setfenv',
+  'getfenv',
+  'log10',
+  'loadstring',
+  'maxn',
+  'loaders',
+  // 5.0 => 5.1: https://www.lua.org/manual/5.1/manual.html#7
+  // deprecated/removed:
+  'gfind',
+  'setn',
+  'mod',
+  'foreach',
+  'foreachi',
+  'gcinfo',
+  // ???:
+  'acequire',
+];
+
+const luaKeyWordsToAdd = [
+  // 5.2: loaders => searchers
+  'searchers',
+];
+
+class NornsLuaRules extends window.ace.acequire('ace/mode/lua_highlight_rules').LuaHighlightRules {
+  constructor() {
+    super();
+    console.log(this.$keywordList);
+    const filteredKeywords = this.$keywordList.filter(k => !includes(luaKeyWordsToFilter, k));
+    this.$keywordList = filteredKeywords.concat(luaKeyWordsToAdd);
+    console.log(this.$keywordList);
+  }
+}
+
+export default class NornsLuaMode extends window.ace.acequire('ace/mode/lua').Mode {
+  constructor() {
+    super();
+    this.HighlightRules = NornsLuaRules;
+  }
+}

--- a/app/src/snippets.js
+++ b/app/src/snippets.js
@@ -1,5 +1,4 @@
-/* eslint no-template-curly-in-string: "off" */
-
+/* eslint-disable no-template-curly-in-string */
 const snippets = {
   cleanup: {
     code: '-- cleanup, release memory\nfunction cleanup()\n  ${0}\nend',
@@ -27,6 +26,7 @@ const snippets = {
   },
   // TODO (pq): add midi, hid, ...
 };
+/* eslint-enable no-template-curly-in-string */
 
 export const nornsSnippetCompleter = {
   getCompletions(editor, session, pos, prefix, callback) {
@@ -49,7 +49,7 @@ export const nornsSnippetCompleter = {
   },
   getDocTooltip(item) {
     if (item.meta === 'norns' && !item.docHTML) {
-      /* eslint no-param-reassign: "off" */
+      /* eslint-disable-next-line no-param-reassign */
       item.docHTML = [
         '<b>',
         item.caption,


### PR DESCRIPTION
* introduces a new lua editor mode that extends the default, swapped in on-render
* rejiggers mode selection and introduces an `editorService`
* fixes over-contribution of norns completions (enabling non-duplicated results w/ no prefix)
* prunes removed/deprecated lúa keywords (notably these were presented in auto-completions)

see: #78

/cc @ngwese 

/fyi @anthonybarsotti @jlmitch5 


(_replaces #116, which i borked on rebase_)
