### PR TITLE
fix icon button jsx

### DIFF
--- a/app/src/icon-button.js
+++ b/app/src/icon-button.js
@@ -108,7 +108,6 @@ class IconButton extends Component {
             className="customTooltip"
           />
         )}
-        )}
       </button>
     );
   }


### PR DESCRIPTION
removes icon button jsx cruft introduced in https://github.com/monome/maiden/commit/4ab596c4c3ca034307c34cf206fb360d25cfc9b2 (formatting).

visible here:

![image](https://user-images.githubusercontent.com/67586/42014544-b0acba72-7a57-11e8-8d72-d965f71f4d08.png)

post-fix:

![image](https://user-images.githubusercontent.com/67586/42014671-556c8b0a-7a58-11e8-8ca3-5557f00ce5fe.png)


/cc @ngwese @Jwhiles
