### PR TITLE
dark editor mode 😎 

### DIFF
--- a/app/src/configure-activity.js
+++ b/app/src/configure-activity.js
@@ -64,6 +64,13 @@ class ConfigureActivity extends Component {
               {this.renderEditorOption('tabSize', 4, 'four')}
             </div>
           </div>
+          <div className="configure-item">
+            <div className="configure-label">editor theme:</div>
+            <div className="configure-options">
+              {this.renderEditorOption('editorTheme', 'dawn', 'light')}
+              {this.renderEditorOption('editorTheme', 'norns_dark', 'dark')}
+            </div>
+          </div>
         </div>
         <div className="configure-lower">
           <div className="configure-about">

--- a/app/src/editor.css
+++ b/app/src/editor.css
@@ -1,3 +1,9 @@
+/* anti-alias where supported */
+* {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
 /* https://stackoverflow.com/questions/26210839/hide-scrollbars-if-not-necessary-ace-editor */
 body .ace_scrollbar {
     -webkit-transition: opacity .3s ease-in-out;
@@ -10,12 +16,33 @@ body .ace_scrollbar {
 body .ace_editor .ace_scrollbar:hover {
     opacity: 1;
 }
-body .ace_editor .ace_gutter-cell.ace_error {
+
+.ace_editor.ace_gutter-cell.ace_error {
     background-image: url("icons/red_x.png");
     background-repeat: no-repeat;
     background-position: 2px center;
 }
 
+.ace_editor.ace_autocomplete.ace_dark .ace_marker-layer .ace_active-line {
+    background-color: rgba(12, 65, 134, 0.486);
+    z-index: 1;
+}
+
+.ace_editor.ace_autocomplete.ace_dark .ace_completion-highlight {
+    color:  rgba(0, 151, 251, 0.911);
+    text-shadow: 0 0 0.01em;
+}
+
+.ace_editor.ace_autocomplete.ace_dark  {
+    width: 280px;
+    z-index: 200000;
+    background: #2f3135;
+    color: #f9f9f9;
+    border: 1px lightgray solid;
+    position: fixed;
+    box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+    line-height: 1.4;
+}
 
 .ace_tooltip {
     background-color: #FFF;
@@ -24,6 +51,31 @@ body .ace_editor .ace_gutter-cell.ace_error {
     border-radius: 1px;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
     color: black;
+    font-family: monospace;
+    max-width: 100%;
+    padding: 3px 4px;
+    position: fixed;
+    z-index: 999999;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    cursor: default;
+    white-space: pre;
+    word-wrap: break-word;
+    line-height: normal;
+    font-style: normal;
+    font-weight: normal;
+    letter-spacing: normal;
+    pointer-events: none;
+}
+
+.ace_dark ~ .ace_tooltip {
+    background-color: #2f3135;
+    background-image: none;
+    border: 1px solid gray;
+    border-radius: 1px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+    color: whitesmoke;
     font-family: monospace;
     max-width: 100%;
     padding: 3px 4px;

--- a/app/src/editor.js
+++ b/app/src/editor.js
@@ -12,6 +12,7 @@ import api from './api';
 import { editorService } from './services';
 
 import './editor.css';
+import './theme/norns_dark';
 
 class Editor extends Component {
   constructor(props) {
@@ -28,6 +29,11 @@ class Editor extends Component {
       delete clonedOpts.keyBoardHandler;
     } else {
       editor.setKeyboardHandler();
+    }
+
+    if (clonedOpts.editorTheme) {
+      // theme is not a session option
+      delete clonedOpts.editorTheme;
     }
 
     session.setOptions(clonedOpts);
@@ -149,11 +155,13 @@ class Editor extends Component {
     const mode = editorService.getMode(this.props.bufferName);
     mode.onRender(this.editor);
 
+    const theme = this.props.editorOptions.editorTheme || 'dawn';
+
     return (
       <AceEditor
         ref="ace"
         mode={mode.id}
-        theme="dawn"
+        theme={theme}
         width={width}
         height={height}
         value={this.props.value}

--- a/app/src/model/config-reducers.js
+++ b/app/src/model/config-reducers.js
@@ -1,7 +1,7 @@
 import { UPDATE_EDITOR_CONFIG_SUCCESS, EDITOR_CONFIG_SUCCESS } from './config-actions';
 
 const initialConfigState = {
-  editor: { tabSize: 2, useSoftTabs: true },
+  editor: { tabSize: 2, useSoftTabs: true, editorTheme: 'dawn' },
 };
 
 const config = (state = initialConfigState, action) => {

--- a/app/src/services.js
+++ b/app/src/services.js
@@ -120,6 +120,7 @@ class LuaMode extends EditorMode {
     this.nornsLuaAceMode = new NornsLuaMode();
   }
   onRender(editor) {
+    if (!editor) return;
     // ensure our contributions are registered.
     const session = editor.getSession();
     if (session.getMode() !== this.nornsLuaAceMode) {

--- a/app/src/theme/norns_dark.js
+++ b/app/src/theme/norns_dark.js
@@ -1,0 +1,130 @@
+// based on "tomorrow night"
+//
+// * suppresses background image on gutter errors / warnings in favor of color (a la "chaos")
+import ace from 'brace';
+
+/* eslint-disable no-param-reassign */
+ace.define(
+  'ace/theme/norns_dark',
+  ['require', 'exports', 'module', 'ace/lib/dom'],
+  (acequire, exports, _) => {
+    exports.isDark = true;
+    exports.cssClass = 'ace-norns-dark';
+    exports.cssText = `
+  .ace-norns-dark .ace_gutter {
+    background: #25282c;
+    color: #C5C8C6
+  }
+  .ace-norns-dark .ace_gutter-cell.ace_warning {
+    background-image: none;
+    background: #FC0;
+    border-left: none;
+    padding-left: 0;
+    color: #000;
+  }
+  .ace-norns-dark .ace_gutter-cell.ace_error {
+    background-position: -6px center;
+    background-image: none;
+    background: #D20E0E;
+    border-left: none;
+    padding-left: 0;
+    color: #000;
+  }
+  .ace-norns-dark .ace_print-margin {
+    width: 1px;
+    background: #25282c
+  }
+  .ace-norns-dark {
+    background-color: #1D1F21;
+    color: #C5C8C6
+  }
+  .ace-norns-dark .ace_cursor {
+    color: #AEAFAD
+  }
+  .ace-norns-dark .ace_marker-layer .ace_selection {
+    background: #373B41
+  }
+  .ace-norns-dark.ace_multiselect .ace_selection.ace_start {
+    box-shadow: 0 0 3px 0px #1D1F21;
+  }
+  .ace-norns-dark .ace_marker-layer .ace_step {
+    background: rgb(102, 82, 0)
+  }
+  .ace-norns-dark .ace_marker-layer .ace_bracket {
+    margin: -1px 0 0 -1px;
+    border: 1px solid #4B4E55
+  }
+  .ace-norns-dark .ace_marker-layer .ace_active-line {
+    background: #282A2E
+  }
+  .ace-norns-dark .ace_gutter-active-line {
+    background-color: #282A2E
+  }
+  .ace-norns-dark .ace_marker-layer .ace_selected-word {
+    border: 1px solid #373B41
+  }
+  .ace-norns-dark .ace_invisible {
+    color: #4B4E55
+  }
+  .ace-norns-dark .ace_keyword,
+  .ace-norns-dark .ace_meta,
+  .ace-norns-dark .ace_storage,
+  .ace-norns-dark .ace_storage.ace_type,
+  .ace-norns-dark .ace_support.ace_type {
+    color: #B294BB
+  }
+  .ace-norns-dark .ace_keyword.ace_operator {
+    color: #8ABEB7
+  }
+  .ace-norns-dark .ace_constant.ace_character,
+  .ace-norns-dark .ace_constant.ace_language,
+  .ace-norns-dark .ace_constant.ace_numeric,
+  .ace-norns-dark .ace_keyword.ace_other.ace_unit,
+  .ace-norns-dark .ace_support.ace_constant,
+  .ace-norns-dark .ace_variable.ace_parameter {
+    color: #DE935F
+  }
+  .ace-norns-dark .ace_constant.ace_other {
+    color: #CED1CF
+  }
+  .ace-norns-dark .ace_invalid {
+    color: #CED2CF;
+    background-color: #DF5F5F
+  }
+  .ace-norns-dark .ace_invalid.ace_deprecated {
+    color: #CED2CF;
+    background-color: #B798BF
+  }
+  .ace-norns-dark .ace_fold {
+    background-color: #81A2BE;
+    border-color: #C5C8C6
+  }
+  .ace-norns-dark .ace_entity.ace_name.ace_function,
+  .ace-norns-dark .ace_support.ace_function,
+  .ace-norns-dark .ace_variable {
+    color: #81A2BE
+  }
+  .ace-norns-dark .ace_support.ace_class,
+  .ace-norns-dark .ace_support.ace_type {
+    color: #F0C674
+  }
+  .ace-norns-dark .ace_heading,
+  .ace-norns-dark .ace_markup.ace_heading,
+  .ace-norns-dark .ace_string {
+    color: #B5BD68
+  }
+  .ace-norns-dark .ace_entity.ace_name.ace_tag,
+  .ace-norns-dark .ace_entity.ace_other.ace_attribute-name,
+  .ace-norns-dark .ace_meta.ace_tag,
+  .ace-norns-dark .ace_string.ace_regexp,
+  .ace-norns-dark .ace_variable {
+    color: #CC6666
+  }
+  .ace-norns-dark .ace_comment {
+    color: #969896
+  }`;
+
+    const dom = acequire('../lib/dom');
+    dom.importCssString(exports.cssText, exports.cssClass);
+  },
+);


### PR DESCRIPTION
norns dark editor mode 

* 🕶  introduces a new norns dark mode editor theme (“norns_dark”), based on “tomorrow night” (w/ error style borrowed from “chaos”); refinements tracked in #122
* 🕶  adds dark mode aware styling of completion and documentation pop-ups
* 🕶  adds a new editor config to toggle modes (light / “dawn” remains default)
* 🎆  **anti-aliases all text** (where supported; sorry windows ☹️ )

a few visuals.

anti-aliasing and error marking:

![image](https://user-images.githubusercontent.com/67586/42112118-b5f8cde6-7b9b-11e8-8752-b9040afb297e.png)

dark mode popup styling:

![image](https://user-images.githubusercontent.com/67586/42112182-e3fe3000-7b9b-11e8-823b-94aee17b9191.png)

editor config:

![image](https://user-images.githubusercontent.com/67586/42112293-301ff374-7b9c-11e8-8920-b987468bb0d2.png)

whole enchilada:

![image](https://user-images.githubusercontent.com/67586/42112251-13f5b36e-7b9c-11e8-8ad3-561d692bc3de.png)

fixes: #33 

@jlmitch5: i **_think_** i wired up the config stuff right but would love confirmation

/cc @ngwese @simonvanderveldt 
