### PR TITLE
disable default (not-working) snippets for text mode (#129)

### DIFF
--- a/app/src/editor.js
+++ b/app/src/editor.js
@@ -169,7 +169,7 @@ class Editor extends Component {
         onChange={this.onChange}
         showPrintMargin={false}
         enableBasicAutocompletion
-        enableSnippets
+        enableSnippets={mode.enableSnippets}
         editorProps={{
           $blockScrolling: Infinity,
           $newLineMode: 'unix',

--- a/app/src/mode.js
+++ b/app/src/mode.js
@@ -1,10 +1,11 @@
 export default class EditorMode {
   constructor(id) {
     this.id = id;
+    this.enableSnippets = true;
   }
 
   /* eslint-disable-next-line no-unused-vars */
   onRender(editor) {
-    // no-op; optionally overridden in subclasses.
+    // no-op; optionally implemented in subclasses.
   }
 }

--- a/app/src/services.js
+++ b/app/src/services.js
@@ -104,6 +104,8 @@ keyService.bindings = [
 class TextMode extends EditorMode {
   constructor() {
     super('text');
+    // https://github.com/monome/maiden/issues/129
+    this.enableSnippets = false;
   }
 }
 


### PR DESCRIPTION
disable default (not-working) snippets for text mode.

fixes: #129 

/cc @ngwese 