### PR TITLE
add ctl/cmd-8 keybinding to eval selection

### DIFF
--- a/web/src/bound-edit-activity.js
+++ b/web/src/bound-edit-activity.js
@@ -129,6 +129,9 @@ const mapDispatchToProps = dispatch => ({
       console.log('resource:', resource, 'cannot be run as a script');
     }
   },
+  selectionEval: code => {
+    dispatch(replSend(MATRON_COMPONENT, code));
+  },
 
   // ui
   sidebarToggle: () => {

--- a/web/src/edit-activity.js
+++ b/web/src/edit-activity.js
@@ -234,6 +234,7 @@ class EditActivity extends Component {
           value={code}
           bufferChange={this.props.bufferChange}
           editorConfig={this.props.editorConfig}
+          selectionEval={this.props.selectionEval}
         />
         <EditTools
           className="edit-tools"

--- a/web/src/editor.js
+++ b/web/src/editor.js
@@ -9,7 +9,7 @@ import 'brace/keybinding/vim';
 import 'brace/keybinding/emacs';
 
 import api from './api';
-import { editorService } from './services';
+import { commandService, editorService } from './services';
 
 import './editor.css';
 import './theme/norns_dark';
@@ -135,18 +135,10 @@ class Editor extends Component {
     this.props.bufferChange(this.props.bufferName, this.getValue());
   }
 
-  /*
-    componentDidMount = () => {
-        // this.editor.focus()
-        window.setTimeout(() => {
-            this.refs.ace.editor.focus();
-            console.log("CDM focused on", this.refs.ace.editor)
-        }, 3);
-
-        //this.refs.ace.editor.focus();
-
-    }
-    */
+  handleEval() {
+    const code = this.editor.getSelectedText();
+    this.props.selectionEval(code);
+  }
 
   render() {
     const width = `${this.props.width}px`;
@@ -156,6 +148,8 @@ class Editor extends Component {
     mode.onRender(this.editor);
 
     const theme = this.props.editorOptions.editorTheme || 'dawn';
+
+    commandService.registerCommand('eval', () => this.handleEval());
 
     return (
       <AceEditor

--- a/web/src/services.js
+++ b/web/src/services.js
@@ -99,6 +99,7 @@ keyService.bindings = [
   new KeyBinding(new KeyStroke(Modifier.CMD, 'e'), 'toggle repl'),
   new KeyBinding(new KeyStroke(Modifier.CMD, 'b'), 'toggle sidebar'),
   new KeyBinding(new KeyStroke(Modifier.CMD, ';'), 'show config'),
+  new KeyBinding(new KeyStroke(Modifier.CMD, '8'), 'eval'),
 ];
 
 class TextMode extends EditorMode {


### PR DESCRIPTION
simple feature to allow the current selection in the editor to be sent to the repl for evaluation. 