### PR TITLE
improve multi-line eval

### DIFF
--- a/web/src/editor.js
+++ b/web/src/editor.js
@@ -136,7 +136,7 @@ class Editor extends Component {
   }
 
   handleEval() {
-    const code = this.editor.getSelectedText();
+    const code = this.editor.getSelectedText().replace(/\-\-.*\n/g,';').replace(/\n/g,';')
     this.props.selectionEval(code);
   }
 


### PR DESCRIPTION
This seems to improve matters when re-eval-ing functions and I tried it on some multi-expression selections.  Let me know if there are other cases where this breaks and thanks for adding the feature.