### PR TITLE
Highlight selected REPL tab more prominently (fixes #90)

### DIFF
--- a/web/src/repl-activity.css
+++ b/web/src/repl-activity.css
@@ -68,6 +68,7 @@
 }
 
 .repl-active-tab {
-    /* color: red; */
     border-bottom: 1px solid rgb(197, 197, 197);
+    color: #757575;
+    font-weight: bold;
 }


### PR DESCRIPTION
before:
![maiden-tab-before](https://user-images.githubusercontent.com/752281/65065536-9a3fe300-d950-11e9-9098-f4d93600b708.png)

after:
![maiden-tab-after](https://user-images.githubusercontent.com/752281/65065545-9dd36a00-d950-11e9-87ab-8d9a7c414e93.png)

Pretty minor change, but I think it does the job. Made sure to use a shade of gray that's used elsewhere in the styles.