### PR TITLE
File rename modal polish

### DIFF
--- a/web/src/modal-get-name.js
+++ b/web/src/modal-get-name.js
@@ -58,7 +58,7 @@ class ModalGetName extends Component {
 
   handleOnChange = () => {
     const newName = this.textArea.value;
-    if (this.siblingNames.has(this.textArea.value)) {
+    if (newName !== this.props.initialName && this.siblingNames.has(newName)) {
       this.setState({
         errorMessage: 'name already in use',
         newName,
@@ -76,7 +76,7 @@ class ModalGetName extends Component {
     }
   };
 
-  isValidName = name => !this.siblingNames.has(name) && !name.startsWith(".");
+  isValidName = name => (name === this.props.initialName || !this.siblingNames.has(name)) && !name.startsWith(".");
 
   complete = choice => {
     const name = this.state.newName;

--- a/web/src/modal-get-name.js
+++ b/web/src/modal-get-name.js
@@ -26,6 +26,7 @@ class ModalGetName extends Component {
     this.state = {
       showError: false,
       errorMessage: '',
+      newName: this.props.initialName,
     };
 
     this.siblingNames = props.getSiblingNames(this.props.selectedResource);
@@ -56,17 +57,21 @@ class ModalGetName extends Component {
   };
 
   handleOnChange = () => {
+    const newName = this.textArea.value;
     if (this.siblingNames.has(this.textArea.value)) {
       this.setState({
         errorMessage: 'name already in use',
+        newName,
       });
     } else if (this.textArea.value.startsWith(".")) {
       this.setState({
-        errorMessage: 'name cannot start with "."'
+        errorMessage: 'name cannot start with "."',
+        newName,
       });
     } else {
       this.setState({
         errorMessage: '',
+        newName,
       });
     }
   };
@@ -74,13 +79,17 @@ class ModalGetName extends Component {
   isValidName = name => !this.siblingNames.has(name) && !name.startsWith(".");
 
   complete = choice => {
-    const name = this.textArea.value;
+    const name = this.state.newName;
     if (choice === 'ok' && !this.isValidName(name)) {
       // prevent completion if name is bad
       return;
     }
-    this.props.buttonAction(choice, this.textArea.value);
+    this.props.buttonAction(choice, this.state.newName);
   };
+
+  componentDidMount() {
+    this.textArea.select();
+  }
 
   render() {
     return (
@@ -92,7 +101,7 @@ class ModalGetName extends Component {
         <textarea
           className="get-name-modal-text-area"
           ref={e => (this.textArea = e)}
-          placeholder={this.props.initialName || ''}
+          value={this.state.newName || ''}
           rows="1"
           maxLength="128"
           wrap="false"

--- a/web/src/model/edit-reducers.js
+++ b/web/src/model/edit-reducers.js
@@ -248,6 +248,7 @@ const handleResourceRenameSuccess = (action, state) => {
     activeBuffer,
     rootNodes,
     buffers,
+    activeNode: newResource,
   };
 };
 


### PR DESCRIPTION
Thought I'd take a stab at #113 too. In the process, I noticed a couple other things:

- `getSiblingNamesForResource` returns the specified resource's name, in addition to those of its siblings, so users would get a "name already in use" error if they clicked Rename and then OK without making any changes. That felt weird to me, so I worked around it. Not sure if I did so in the best possible way (perhaps getSiblingNames... should be modified instead, but I was daunted by all the immutable.js stuff).
- After renaming a file, the explorer's `activeNode` becomes undefined, so if you click the rename button again, nothing happens. I feel pretty confident that I fixed this in the Correct Way, but I'd welcome any corrections!