### PR TITLE
Fix `scrollTo` error in MS Edge (fixes #157)

### DIFF
--- a/web/src/repl.js
+++ b/web/src/repl.js
@@ -14,7 +14,7 @@ class ReplOutput extends Component {
   componentDidUpdate() {
     // FIXME: this always forces scrolling to the bottom
     if (this.output) {
-      this.output.scrollTo(0, this.output.scrollHeight);
+      this.output.scrollTop = this.output.scrollHeight;
     }
   }
 


### PR DESCRIPTION
Picking more low-hanging fruit; apparently MS [didn't bother to implement](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo) element.scrollTo(), but setting scrollTop is a viable alternative.