### PR TITLE
Fix CTRL+P in editor

### DIFF
--- a/web/src/edit-activity.js
+++ b/web/src/edit-activity.js
@@ -232,8 +232,6 @@ class EditActivity extends Component {
           bufferChange={this.props.bufferChange}
           editorConfig={this.props.editorConfig}
           selectionEval={this.props.selectionEval}
-          activityActiveBuffer={this.props.activeBuffer}
-          scriptRun={this.props.scriptRun}
         />
         <EditTools
           className="edit-tools"

--- a/web/src/edit-activity.js
+++ b/web/src/edit-activity.js
@@ -232,6 +232,8 @@ class EditActivity extends Component {
           bufferChange={this.props.bufferChange}
           editorConfig={this.props.editorConfig}
           selectionEval={this.props.selectionEval}
+          activityActiveBuffer={this.props.activeBuffer}
+          scriptRun={this.props.scriptRun}
         />
         <EditTools
           className="edit-tools"

--- a/web/src/editor.js
+++ b/web/src/editor.js
@@ -30,8 +30,10 @@ class Editor extends Component {
         editor.setKeyboardHandler(clonedOpts.keyBoardHandler, () => {
           const { $handlers } = editor.keyBinding;
           const handler = $handlers[$handlers.length - 1];
-          const cpIndex = handler.defaultKeymap.findIndex(x => x.keys == '<C-p>');
-          handler.defaultKeymap.splice(cpIndex, 1);
+          const cpIndex = handler.defaultKeymap.findIndex(x => x.keys === '<C-p>');
+          if (~cpIndex) {
+            handler.defaultKeymap.splice(cpIndex, 1);
+          }
         });
       }
       delete clonedOpts.keyBoardHandler;

--- a/web/src/editor.js
+++ b/web/src/editor.js
@@ -26,7 +26,14 @@ class Editor extends Component {
     const clonedOpts = JSON.parse(JSON.stringify(opts));
 
     if (clonedOpts.keyBoardHandler) {
-      editor.setKeyboardHandler(clonedOpts.keyBoardHandler);
+      if (clonedOpts.keyBoardHandler.includes('vim')) {
+        editor.setKeyboardHandler(clonedOpts.keyBoardHandler, () => {
+          const { $handlers } = editor.keyBinding;
+          const handler = $handlers[$handlers.length - 1];
+          const cpIndex = handler.defaultKeymap.findIndex(x => x.keys == '<C-p>');
+          handler.defaultKeymap.splice(cpIndex, 1);
+        });
+      }
       delete clonedOpts.keyBoardHandler;
     } else {
       editor.setKeyboardHandler();
@@ -145,6 +152,9 @@ class Editor extends Component {
     const width = `${this.props.width}px`;
     const height = `${this.props.height}px`;
 
+    const getActiveBuffer = () => this.props.activityActiveBuffer;
+    const { scriptRun } = this.props;
+
     const mode = editorService.getMode(this.props.bufferName);
     mode.onRender(this.editor);
 
@@ -169,6 +179,13 @@ class Editor extends Component {
           $blockScrolling: Infinity,
           $newLineMode: 'unix',
         }}
+        commands={[{
+          name: 'play',
+          bindKey: { win: 'Ctrl-P', mac: 'Ctrl-P' },
+          exec: () => { 
+            scriptRun && scriptRun(getActiveBuffer());
+          }
+        }]}
       />
     );
   }

--- a/web/src/services.js
+++ b/web/src/services.js
@@ -38,6 +38,14 @@ class KeyStroke {
     return OS.isMac ? this.mac : this.win;
   }
 
+  get vimKey() {
+    return `<C-${this.key}>`;
+  }
+  
+  osModKey(os) {
+    return `${Modifier[os][this.modifier].name}-${this.key}`
+  }
+
   matches(event) {
     if (!this.osModifier.matches(event)) {
       return false;
@@ -50,6 +58,21 @@ class KeyBinding {
   constructor(keystroke, commandId) {
     this.keystroke = keystroke;
     this.commandId = commandId;
+  }
+
+  get aceCommand() {
+    const name = this.commandId;
+    return {
+      name,
+      bindKey: { 
+        win: this.keystroke.osModKey('win'),
+        mac: this.keystroke.osModKey('mac'),
+      },
+      exec: () => {
+        const command = commandService.commands.get(name);
+        command && command();
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This fixes `CTRL+P` in the editor for "playing" the current script (fix #71). I tested it for the default Ace keybindings and for the Vim ones. The existing keybindings applied to the window, but were overridden by the Ace editor and it appears that their default/lower-precedence behaviors were prevented.

The significant change is twofold. First, the relevant `activeBuffer` and `scriptRun()` props are passed from `EditActivity` to its `Editor`. The former had to be aliased to `activityActiveBuffer` due to conflicts surfaced in testing. This is then wrapped in a `getActiveBuffer()` helper in `render()` to ensure freshness. Next, a `commands` prop is passed to said `Editor`, which is an array of commands associated with keys. The sole member of `commands` is a mapping of `CTRL+P` to a call to `scriptRun` with the active buffer. 

Next, for Vim, the `<C-p>` mapping found in the defaults is just removed. The Vim keybindings take priority in Ace, and removing that binding from Vim forces it to fall back to the main binding list, which includes the aforementioned `CTRL+P` mapping.