### PR TITLE
Project ux enhancements

### DIFF
--- a/web/src/api.js
+++ b/web/src/api.js
@@ -227,7 +227,7 @@ class API {
   static updateProject(projectURL, onSuccess, onFailure) {
     // FIXME: this really shouldn't be a GET verb
     const url = `${projectURL}?update=`;
-    fetch(url, {'method': 'GET'}).then(response => {
+    return fetch(url, {'method': 'GET'}).then(response => {
       const cb = response.ok ? onSuccess : onFailure;
       response.json().then(body => {
         cb(body);

--- a/web/src/bound-project-activity.js
+++ b/web/src/bound-project-activity.js
@@ -10,6 +10,7 @@ import {
   getProjectSummary,
   getProject,
   installProject,
+  updateAllProjects,
   updateProject,
   removeProject,
 } from './model/project-actions';
@@ -58,6 +59,9 @@ const mapDispatchToProps = dispatch => ({
   },
   installProject: (catalogURL, name, onSuccess, onFailure) => {
     dispatch(installProject(catalogURL, name, onSuccess, onFailure));
+  },
+  updateAllProjects: (projectList, onSuccess, onFailure) => {
+    dispatch(updateAllProjects(projectList, onSuccess, onFailure));
   },
   updateProject: (projectURL, name, onSuccess, onFailure) => {
     dispatch(updateProject(projectURL, name, onSuccess, onFailure));

--- a/web/src/components/catalog-list.js
+++ b/web/src/components/catalog-list.js
@@ -8,7 +8,7 @@ const CatalogList = props => {
     const catalog = props.catalogs.get(name);
     return (
       <li key={name}>
-        <Catalog catalog={catalog} installAction={props.installAction} refreshAction={props.refreshAction} />
+        <Catalog catalog={catalog} installedProjects={props.installedProjects} installAction={props.installAction} refreshAction={props.refreshAction} />
       </li>
     );
   });

--- a/web/src/components/catalog.css
+++ b/web/src/components/catalog.css
@@ -23,3 +23,11 @@
 .catalog-entries > li {
   margin: 0 0 4px 0;
 }
+
+.catalog-installedLabel {
+  font-style: italic;
+  font-family: monospace;
+  width: 10em;
+  text-align: center;
+  color: rgb(204, 204, 204);
+}

--- a/web/src/components/catalog.js
+++ b/web/src/components/catalog.js
@@ -10,22 +10,29 @@ import ProjectControl from './project-control';
 import './catalog.css';
 
 const Catalog = (props) => {
-  const {catalog} = props;
+  const {catalog, installedProjects} = props;
   const catalogURL = catalog.get('url');
 
   const entries = catalog.get('entries').map(e => {
     const projectName = e.get('project_name');
     const projectURL = e.get('project_url');
     const key = `${projectName}-${projectURL || ""}`; // to silence warnings
+
     return (
       <li key={key}>
       <ProjectControl>
         <ProjectInfo project={e} />
-        <TextButton color="hsl(0, 0%, 59%)"
-          action={() => props.installAction(catalogURL, projectName)}
-        >
-          install
-        </TextButton>
+        {(installedProjects || []).indexOf(projectName) === -1 ? (
+          <TextButton color="hsl(0, 0%, 59%)"
+            action={() => props.installAction(catalogURL, projectName)}
+          >
+            install
+          </TextButton>
+        ) : (
+          <div className='catalog-installedLabel'>
+              already installed
+          </div>
+        )}
       </ProjectControl>
       </li>
     );

--- a/web/src/components/project-list.css
+++ b/web/src/components/project-list.css
@@ -1,3 +1,9 @@
+.project-list-container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
 .project-listing {
   list-style: none;
   margin: 0px;
@@ -6,4 +12,13 @@
 
 .project-listing li {
   margin: 0 0 4px 0;
+}
+
+.project-updateAllButton {
+  color: rgb(150, 150, 150);
+  background: rgb(249, 249, 249);
+  padding: 15px;
+  width: 20em;
+  margin-right: 32px;
+  margin-bottom: 5px;
 }

--- a/web/src/components/project-list.css
+++ b/web/src/components/project-list.css
@@ -5,6 +5,7 @@
 }
 
 .project-listing {
+  width: 100%;
   list-style: none;
   margin: 0px;
   padding: 0px;

--- a/web/src/components/project-list.js
+++ b/web/src/components/project-list.js
@@ -7,8 +7,9 @@ import ProjectControl from './project-control';
 import './project-list.css';
 
 const ProjectList = props => {
-  const { projects, updateAction, removeAction } = props;
+  const { projects, updateAllAction, updateAction, removeAction } = props;
   let entries = undefined;
+  const projectList = projects.get('projects') ? projects.get('projects').map(e => ({url: e.get('url'), name: e.get('project_name')})).toArray() : [];
   if (projects && projects.has('projects')) {
     entries = projects.get('projects').map(p => {
       // layer project data over catalog entry (if it exists)
@@ -43,6 +44,11 @@ const ProjectList = props => {
 
   return (
     <div className='project-list-container'>
+      {projectList.length ? (<TextButton
+        classes='project-updateAllButton'
+        color='hsl(0, 0%, 59%)' 
+        action={() => updateAllAction(projectList)}
+      >update all</TextButton>) : ''}
       <ul className='project-listing'>
         {entries}
       </ul>

--- a/web/src/components/text-button.js
+++ b/web/src/components/text-button.js
@@ -67,7 +67,7 @@ class TextButton extends Component {
   render() {
     const style = {color: this.state.color};
     return (
-      <button className='text-button'
+      <button className={`text-button ${this.props.classes ? ` ${this.props.classes}` : ''}`}
         onClick={this.handleClick}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}

--- a/web/src/modal-content.css
+++ b/web/src/modal-content.css
@@ -26,3 +26,13 @@
     color: rgb(151, 80, 49);
     height: 1em;
 }
+
+.modal-content table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.modal-content td {
+    padding: 5px;
+    border: 1px solid #ccc;
+}

--- a/web/src/modal-content.js
+++ b/web/src/modal-content.js
@@ -34,7 +34,7 @@ const ModalContent = props => {
   }
 
   return (
-    <div className="modal-content">
+    <div className="modal-content" style={props.style}>
       <div className="message-container">
         <span className="message">{props.message}</span>
         <p />

--- a/web/src/model/project-actions.js
+++ b/web/src/model/project-actions.js
@@ -27,6 +27,9 @@ export const PROJECT_INSTALL_REQUEST = 'PROJECT_INSTALL_REQUEST';
 export const PROJECT_INSTALL_SUCCESS = 'PROJECT_INSTALL_SUCCESS';
 export const PROJECT_INSTALL_FAILURE = 'PROJECT_INSTALL_FAILURE';
 
+export const PROJECT_UPDATE_ALL_SUCCESS = 'PROJECT_UPDATE_ALL_SUCCESS';
+export const PROJECT_UPDATE_ALL_FAILURE = 'PROJECT_UPDATE_ALL_FAILURE';
+
 export const PROJECT_UPDATE_REQUEST = 'PROJECT_UPDATE_REQUEST';
 export const PROJECT_UPDATE_SUCCESS = 'PROJECT_UPDATE_SUCCESS';
 export const PROJECT_UPDATE_FAILURE = 'PROJECT_UPDATE_FAILURE';
@@ -64,6 +67,9 @@ export const projectViewSelect = component => ({ type: PROJECT_VIEW_SELECT, comp
 export const projectInstallRequest = (catalog, name) => ({ type: PROJECT_INSTALL_REQUEST, catalog, name });
 export const projectInstallSuccess = (project, catalog, name) => ({ type: PROJECT_INSTALL_SUCCESS, project, catalog, name });
 export const projectInstallFailure = (error, catalog, name) => ({ type: PROJECT_INSTALL_FAILURE, error, catalog, name });
+
+export const projectUpdateAllSuccess = (successArr) => ({ type: PROJECT_UPDATE_ALL_SUCCESS, successArr });
+export const projectUpdateAllFailure = (successArr, failureArr) => ({ type: PROJECT_UPDATE_ALL_FAILURE, successArr, failureArr });
 
 export const projectUpdateRequest = (project, name) => ({ type: PROJECT_UPDATE_REQUEST, project, name });
 export const projectUpdateSuccess = (project, name) => ({ type: PROJECT_UPDATE_SUCCESS, project, name });
@@ -179,6 +185,35 @@ export const installProject = (catalog, name, onSuccess, onFailure) => dispatch 
         onFailure(failureResult);
       }
     });
+};
+
+export const updateAllProjects = (projects, onSuccess, onFailure) => dispatch => {
+  const successArr = [];
+  const failureArr = [];
+  const requestsArr = projects.map(({url,name}) => {
+    dispatch(projectUpdateRequest(url, name));
+    return API.updateProject(url, 
+      successResult => {
+        successArr.push({successResult, url, name});
+      },
+      failureResult => {
+        failureArr.push({failureResult, url, name});
+      });
+  });
+
+  Promise.all(requestsArr).then(_ => {
+    if (failureArr.length) {
+      dispatch(projectUpdateAllFailure(successArr, failureArr));
+      if (onFailure) {
+        onFailure(successArr, failureArr);
+      }
+    } else {
+      dispatch(projectUpdateAllSuccess(successArr));
+      if (onSuccess) {
+        onSuccess(successArr);
+      }
+    }
+  });
 };
 
 export const updateProject = (project, name, onSuccess, onFailure) => dispatch => {

--- a/web/src/model/project-actions.js
+++ b/web/src/model/project-actions.js
@@ -190,17 +190,24 @@ export const installProject = (catalog, name, onSuccess, onFailure) => dispatch 
 export const updateAllProjects = (projects, onSuccess, onFailure) => dispatch => {
   const successArr = [];
   const failureArr = [];
-  const requestsArr = projects.map(({url,name}) => {
+  const requestsArr = [];
+  projects.forEach(({url,name}) => {
     dispatch(projectUpdateRequest(url, name));
-    return API.updateProject(url, 
-      successResult => {
-        successArr.push({successResult, url, name});
-      },
-      failureResult => {
-        failureArr.push({failureResult, url, name});
-      });
+    const promise = new Promise((resolve) => {
+      API.updateProject(url, 
+        successResult => {
+          successArr.push({successResult, url, name});
+          resolve('resolved');
+        },
+        failureResult => {
+          console.log("got here")
+          failureArr.push({failureResult, url, name});
+          resolve('resolved');
+        });
+    });
+    console.log(promise);
+    requestsArr.push(promise);
   });
-
   Promise.all(requestsArr).then(_ => {
     if (failureArr.length) {
       dispatch(projectUpdateAllFailure(successArr, failureArr));

--- a/web/src/project-activity.js
+++ b/web/src/project-activity.js
@@ -98,6 +98,7 @@ class ProjectActivity extends Component {
       if (choice === 'ok') {
         this.props.updateAllProjects(projectList,
           successArr => {
+            successArr = successArr.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
             this.props.getProjectSummary();
             this.props.refreshCodeDir();
             this.props.showModal(<ModalContent
@@ -109,11 +110,14 @@ class ProjectActivity extends Component {
             />)
           },
           (successArr, failureArr) => {
+            successArr = successArr.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
+            failureArr = failureArr.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
+            this.props.getProjectSummary();
+            this.props.refreshCodeDir();
             this.props.showModal(<ModalContent
               message='Updating all projects failed.'
-              supporting={`${successArr.length ? `The following projects were updated:\n\n${successArr.map(e => e.name).join('\n')}.\n\n` : ''}
-              The following errors happened:\n\n${failureArr.map(e => `${e.name}: ${e.failureResult.error}`).join('\n')}`}
-              style={{whiteSpace: 'pre-line'}}
+              supporting={<span>{successArr.length ? (<div>The following projects were updated:<br /><br /><table><tbody>{successArr.map(e => (<tr><td>{e.name}</td></tr>))}</tbody></table><br /><br /></div>) : ''}
+              <div>The following errors happened:<br /><br /><table><tbody>{failureArr.map(e => (<tr><td style={{ width: '100px' }}>{e.name}</td><td style={{ width: 'auto' }}>{e.failureResult.error}</td></tr>))}</tbody></table></div></span>}
               buttonAction={this.modalDismiss}
               confirmOnly={true}
             />)
@@ -121,7 +125,7 @@ class ProjectActivity extends Component {
         this.props.showModal(
           <ModalContent
             message='Updating all projects'
-            supporting="Updating all projects in progress"
+            supporting="please wait..."
             buttonAction={this.modalDismiss}
             confirmOnly={true}
           />
@@ -129,6 +133,19 @@ class ProjectActivity extends Component {
       } else {
         // update request canceled
         this.props.hideModal();
+        <table>
+    <thead>
+        <tr>
+            <th colspan="2">The table header</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>The table body</td>
+            <td>with two columns</td>
+        </tr>
+    </tbody>
+</table>
       }
     };
 

--- a/web/src/project-activity.js
+++ b/web/src/project-activity.js
@@ -93,6 +93,56 @@ class ProjectActivity extends Component {
     return(content);
   };
 
+  handleUpdateAllAction = (projectList) => {
+    const modalCompletion = choice => {
+      if (choice === 'ok') {
+        this.props.updateAllProjects(projectList,
+          successArr => {
+            this.props.getProjectSummary();
+            this.props.refreshCodeDir();
+            this.props.showModal(<ModalContent
+              message='Updating all projects succeeded.'
+              supporting={`${successArr.length ? `The following projects were updated:\n\n${successArr.map(e => e.name).join('\n')}.` : ''}`}
+              style={{whiteSpace: 'pre-line'}}
+              buttonAction={this.modalDismiss}
+              confirmOnly={true}
+            />)
+          },
+          (successArr, failureArr) => {
+            this.props.showModal(<ModalContent
+              message='Updating all projects failed.'
+              supporting={`${successArr.length ? `The following projects were updated:\n\n${successArr.map(e => e.name).join('\n')}.\n\n` : ''}
+              The following errors happened:\n\n${failureArr.map(e => `${e.name}: ${e.failureResult.error}`).join('\n')}`}
+              style={{whiteSpace: 'pre-line'}}
+              buttonAction={this.modalDismiss}
+              confirmOnly={true}
+            />)
+          });
+        this.props.showModal(
+          <ModalContent
+            message='Updating all projects'
+            supporting="Updating all projects in progress"
+            buttonAction={this.modalDismiss}
+            confirmOnly={true}
+          />
+        );
+      } else {
+        // update request canceled
+        this.props.hideModal();
+      }
+    };
+
+    const modalContent = (
+      <ModalContent
+        message={`Update all projects?`}
+        supporting="Local modifications will be overwritten"
+        buttonAction={modalCompletion}
+      />
+    );
+
+    this.props.showModal(modalContent);
+  };
+
 
   handleUpdateAction = (url, name) => {
     console.log('doing update', url);
@@ -179,12 +229,14 @@ class ProjectActivity extends Component {
           <ProjectList
             name='installed'
             projects={this.props.projectSummary}
+            updateAllAction={this.handleUpdateAllAction}
             updateAction={this.handleUpdateAction}
             removeAction={this.handleRemoveAction}
           />
           <CatalogList
             name='available'
             catalogSummary={this.props.catalogSummary}
+            installedProjects={this.props.projectSummary.get('projects') && this.props.projectSummary.get('projects').map(e => e.get('project_name'))}
             catalogs={this.props.catalogs}
             installAction={this.handleInstallAction}
             refreshAction={this.handleRefreshAction}


### PR DESCRIPTION
fixes https://github.com/monome/maiden/issues/175

DONE

on the available packages list, change the install button to non-clickable, installed grey text

<img width="843" alt="Screen Shot 2020-01-18 at 10 32 54 PM" src="https://user-images.githubusercontent.com/1342624/72674357-6205f980-3a43-11ea-8474-90b53983c0cd.png">

---

on the installed packages list, have an "update all" button at the top, which only has a single confirmation dialog after clicking "update all", then recursively goes through each installed package and tries to update.

![Screen Shot 2020-01-19 at 1 55 31 PM](https://user-images.githubusercontent.com/1342624/72686879-e77ebd80-3ac6-11ea-982d-ff7dbaa81236.png)

![Screen Shot 2020-01-19 at 1 55 37 PM](https://user-images.githubusercontent.com/1342624/72686885-ec437180-3ac6-11ea-9bf3-44bdf02a32fe.png)

![Screen Shot 2020-01-19 at 2 12 08 PM](https://user-images.githubusercontent.com/1342624/72686888-ee0d3500-3ac6-11ea-9327-1e66432b17dc.png)

![Screen Shot 2020-01-19 at 2 11 52 PM](https://user-images.githubusercontent.com/1342624/72686890-f1082580-3ac6-11ea-8767-54c00d346e48.png)

This last modal will change the header to succeeded if no projects fail.  If a combination of succeeded and failed updates happen it should show the succeeded projects in a list, then the failed ones in a list (with the reason, like shown in the screenshot above).