### PR TITLE
catalog refresh

### DIFF
--- a/cmd/catalog_update.go
+++ b/cmd/catalog_update.go
@@ -36,6 +36,11 @@ func downloadURLToFile(filepath string, url string) error {
 		logger.Debug("url get failed: ", err)
 		return err
 	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed for %s, status: %d", url, resp.StatusCode)
+	}
+
 	defer resp.Body.Close()
 
 	logger.Debug("creating file: ", filepath)
@@ -93,7 +98,7 @@ func CatalogUpdateRun(args []string) {
 		case "download":
 			DownloadCatalog(loaded.Source, outputPath)
 		default:
-			fmt.Println("unrecognize catalog source:", sourceMethod)
+			fmt.Println("unrecognized catalog source:", sourceMethod)
 		}
 	}
 }
@@ -136,7 +141,7 @@ func DownloadCatalog(source *catalog.Source, outputPath string) {
 
 	fmt.Printf("fetching %s... ", url)
 	if err := downloadURLToFile(outputPath, url); err != nil {
-		logger.Fatal(err)
+		logger.Warn(err)
 	}
 	fmt.Printf("wrote: %s\n", outputPath)
 }

--- a/web/src/bound-project-activity.js
+++ b/web/src/bound-project-activity.js
@@ -7,6 +7,7 @@ import {
   getCatalog,
   getCatalogByURL,
   updateCatalog,
+  updateAllCatalogs,
   getProjectSummary,
   getProject,
   installProject,
@@ -47,6 +48,9 @@ const mapDispatchToProps = dispatch => ({
   },
   updateCatalog: (catalogURL, onSuccess, onFailure) => {
     dispatch(updateCatalog(catalogURL, onSuccess, onFailure));
+  },
+  updateAllCatalogs: (catalogSummary, onSuccess, onFailure) => {
+    dispatch(updateAllCatalogs(catalogSummary, onSuccess, onFailure));
   },
   refreshCodeDir: () => {
     dispatch(directoryRead(DUST_CODE_RESOURCE));

--- a/web/src/components/catalog-list.css
+++ b/web/src/components/catalog-list.css
@@ -1,4 +1,10 @@
+.catalog-list-container {
+  display: flex;
+  flex-direction: column;
+}
+
 .catalog-list {
+  width: 100%;
   list-style: none;
   margin: 0px;
   padding: 0px;
@@ -6,4 +12,14 @@
 
 .catalog-list li {
   margin: 0 0 8px 0;
+}
+
+.catalog-refresh-all-button {
+  color: rgb(150, 150, 150);
+  background: rgb(249, 249, 249);
+  padding: 15px;
+  width: 95%;
+  margin-right: 8px;
+  margin-bottom: 5px;
+  align-self: center;
 }

--- a/web/src/components/catalog-list.js
+++ b/web/src/components/catalog-list.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Catalog from './catalog';
 import './catalog-list.css';
+import TextButton from './text-button';
 
 const CatalogList = props => {
   const catalogs = props.catalogSummary.valueSeq().map(c => {
@@ -13,9 +14,16 @@ const CatalogList = props => {
     );
   });
   return (
-    <ul className='catalog-list'>
-      {catalogs}
-    </ul>
+    <div className='catalog-list-container'>
+      {catalogs.size ? (<TextButton
+        classes='catalog-refresh-all-button'
+        color='hsl(0, 0%, 45%)'
+        action={() => props.refreshAllAction(props.catalogSummary)}
+        >refresh all</TextButton>) : ''}
+      <ul className='catalog-list'>
+        {catalogs}
+      </ul>
+    </div>
   );
 };
 

--- a/web/src/components/project-list.css
+++ b/web/src/components/project-list.css
@@ -1,7 +1,6 @@
 .project-list-container {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
 }
 
 .project-listing {
@@ -19,7 +18,8 @@
   color: rgb(150, 150, 150);
   background: rgb(249, 249, 249);
   padding: 15px;
-  width: 20em;
-  margin-right: 32px;
+  width: 95%;
+  margin-right: 8px;
   margin-bottom: 5px;
+  align-self: center;
 }

--- a/web/src/project-activity.js
+++ b/web/src/project-activity.js
@@ -52,6 +52,82 @@ class ProjectActivity extends Component {
       });
   };
 
+  handleRefreshAllAction = (catalogSummary) => {
+    const modalCompletion = choice => {
+      if (choice === 'ok') {
+        this.props.updateAllCatalogs(catalogSummary, (successArr, failureArr) => {
+          this.props.showModal(this.updateRefreshAllModalContent(successArr, failureArr));
+        });
+
+        this.props.showModal(
+          <ModalContent
+            message='Refreshing all catalogs'
+            supporting="please wait..."
+            buttonAction={this.modalDismiss}
+            confirmOnly={true}
+          />
+        );
+      } else {
+        // update request canceled
+        this.props.hideModal();
+      }
+    };
+
+    this.props.showModal(
+      <ModalContent
+        message={`Refresh all catalogs?`}
+        buttonAction={modalCompletion}
+      />
+    );
+  };
+
+  updateRefreshAllModalContent = (successArr, failureArr) => {
+    let success = undefined;
+    if (successArr && successArr.length) {
+      success = (
+        <div>
+          <span className='project-activity-update-modal-section-header'>Updated</span>
+          <br /><br />
+          <table>
+            <tbody>
+              {successArr.map(e => (<tr><td>{e.name}</td></tr>))}
+            </tbody>
+          </table><br /><br />
+        </div>
+      );
+    }
+
+    let failure = undefined;
+    if (failureArr && failureArr.length) {
+      failure = (
+        <div>
+          <span className='project-activity-update-modal-section-header'>Failed</span>
+          <br /><br />
+          <table>
+            <tbody>
+              {failureArr.map(e => (
+                <tr>
+                  <td style={{ width: '100px' }}>{e.name}</td>
+                  <td style={{ width: 'auto' }}>{e.failureResult.error}</td>
+                </tr>))}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+
+    return (
+      <ModalContent
+        buttonAction={this.modalDismiss}
+        confirmOnly={true}
+      >
+        {success}
+        {failure}
+      </ModalContent>
+    )
+  };
+
+
   handleInstallAction = (url, name) => {
     console.log('doing install', url, name);
 
@@ -278,6 +354,7 @@ class ProjectActivity extends Component {
             catalogSummary={this.props.catalogSummary}
             installedProjects={this.props.projectSummary.get('projects') && this.props.projectSummary.get('projects').map(e => e.get('project_name'))}
             catalogs={this.props.catalogs}
+            refreshAllAction={this.handleRefreshAllAction}
             installAction={this.handleInstallAction}
             refreshAction={this.handleRefreshAction}
           />


### PR DESCRIPTION
- adds automatic refresh on device startup
- adds giant refresh all button at top of the `available` (aka catalog) view which fetches updates to all the catalogs

given the way the catalog stuff works internally these changes fall short of delivering the desired user experience. specifically:
- the completion dialog for the refresh all catalog action only lists the catalogs which were updated but it doesn't give any indication if there were new entries or not
- catalogs which fail to update will be reported as having been updated _if the catalog was downloaded previously_. update failures are only shown if the catalog does not exist on the device

fixes: #184 