### PR TITLE
upgrades react-ace to latest version

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
     "macaddress": "^0.2.9",
     "parse-filepath": "^1.0.2",
     "react": "^16.8",
-    "react-ace": "^5.10.0",
+    "react-ace": "^9.2.1",
     "react-dom": "^16.8",
     "react-linkify": "^0.2.2",
     "react-modal": "^3.8",

--- a/web/src/editor.js
+++ b/web/src/editor.js
@@ -40,6 +40,7 @@ class Editor extends Component {
     }
 
     session.setOptions(clonedOpts);
+    session.setUseWrapMode(true);
   };
 
   removeConflictingBindings = (editor, handlerName) => {

--- a/web/src/editor.js
+++ b/web/src/editor.js
@@ -1,13 +1,13 @@
 import React, { Component } from 'react';
 import AceEditor from 'react-ace';
-import 'brace/ext/language_tools';
-import 'brace/ext/searchbox';
-import 'brace/mode/lua';
-import 'brace/mode/json';
-import 'brace/snippets/lua';
-import 'brace/theme/dawn';
-import 'brace/keybinding/vim';
-import 'brace/keybinding/emacs';
+import 'ace-builds/src-noconflict/ext-language_tools';
+import 'ace-builds/src-noconflict/ext-searchbox';
+import 'ace-builds/src-noconflict/mode-lua'
+import 'ace-builds/src-noconflict/mode-json'
+import 'ace-builds/src-noconflict/snippets/lua';
+import 'ace-builds/src-noconflict/theme-dawn';
+import 'ace-builds/src-noconflict/keybinding-vim';
+import 'ace-builds/src-noconflict/keybinding-emacs';
 
 import api from './api';
 import { commandService, editorService, keyService } from './services';

--- a/web/src/mode/lua.js
+++ b/web/src/mode/lua.js
@@ -1,5 +1,5 @@
-import 'brace/mode/lua';
-import 'brace/mode/text';
+import 'ace-builds/src-noconflict/mode-lua';
+import 'ace-builds/src-noconflict/mode-text';
 
 import EditorMode from '../mode';
 import { nornsSnippetCompleter } from '../snippets';

--- a/web/src/theme/norns_dark.js
+++ b/web/src/theme/norns_dark.js
@@ -1,7 +1,7 @@
 // based on "tomorrow night"
 //
 // * suppresses background image on gutter errors / warnings in favor of color (a la "chaos")
-import ace from 'brace';
+import ace from 'ace-builds/src-noconflict/ace';
 
 /* eslint-disable no-param-reassign */
 ace.define(

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1680,6 +1680,11 @@ accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+ace-builds@^1.4.6:
+  version "1.4.12"
+  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.4.12.tgz#888efa386e36f4345f40b5233fcc4fe4c588fae7"
+  integrity sha512-G+chJctFPiiLGvs3+/Mly3apXTcfgE45dT5yp12BcWZ1kUs+gm0qd3/fv4gsz6fVag4mM0moHVpjHDIgph6Psg==
+
 acorn-dynamic-import@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz#c752bd210bef679501b6c6cb7fc84f8f47158cc4"
@@ -3436,11 +3441,6 @@ brace-expansion@^1.0.0, brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/brace/-/brace-0.11.1.tgz#4896fcc9d544eef45f4bb7660db320d3b379fe58"
-  integrity sha1-SJb8ydVE7vRfS7dmDbMg07N5/lg=
-
 braces@^1.8.2:
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
@@ -4961,6 +4961,11 @@ detect-port@^1.2.3:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
+
+diff-match-patch@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.5.tgz#abb584d5f10cd1196dfc55aa03701592ae3f7b37"
+  integrity sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==
 
 diff@^3.2.0:
   version "3.4.0"
@@ -8711,7 +8716,7 @@ lodash.isarray@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
   integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
 
-lodash.isequal@^4.1.1, lodash.isequal@^4.5.0:
+lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
@@ -10975,15 +10980,16 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-ace@^5.10.0:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/react-ace/-/react-ace-5.10.0.tgz#e328b37ac52759f700be5afdb86ada2f5ec84c5e"
-  integrity sha512-aEK/XZCowP8IXq91e2DYqOtGhabk1bbjt+fyeW0UBcIkzDzP/RX/MeJKeyW7wsZcwElACVwyy9nnwXBTqgky3A==
+react-ace@^9.2.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/react-ace/-/react-ace-9.2.1.tgz#1efaa0476c77649136def50e5c4ca30c7e546036"
+  integrity sha512-2arIeMER/W6/h+QGHs0YJ0pEJo5AmBOUs/R72Poa6eXSOSTpJPp/WkwD/KE7BgNy9vZ7YjlbqA+2ZcoVf6AjsQ==
   dependencies:
-    brace "^0.11.0"
+    ace-builds "^1.4.6"
+    diff-match-patch "^1.0.4"
     lodash.get "^4.4.2"
-    lodash.isequal "^4.1.1"
-    prop-types "^15.5.8"
+    lodash.isequal "^4.5.0"
+    prop-types "^15.7.2"
 
 react-clientside-effect@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
- upgrades to latest react-ace builds, which:
- fixes indention of `end` keywords
- not longer flags `<<` and `>>` as syntax errors in lua mode

in addition this enables soft line wrapping on the editor

fixes: #9 