### PR TITLE
restore special handling of line endings for supercollider repl

### DIFF
--- a/web/src/model/repl-reducers.js
+++ b/web/src/model/repl-reducers.js
@@ -71,7 +71,7 @@ const handleReplSend = (action, state, conn) => {
     console.log("No socket; can't send", action.value, 'to', action.component);
     return state;
   }
-  if (action.component === 'sc') {
+  if (action.component === 'supercollider') {
     // lame, sclang expects commands to be terminated with special command bytes
     socket.send(`${action.value}\x1b`);
   } else {


### PR DESCRIPTION
the recent change renaming the `sc` repl to the `supercollider`
repl broke logic which was conditioned on the name of the repl

fixes: #198 