### PR TITLE
removing 'update failed' if already up to date

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -720,10 +720,12 @@ func (s *server) getProjectHandler(ctx *gin.Context) {
 		// ignore the value for now but it could be a commit or version in the future?
 		if p.IsManaged() {
 			if err := p.Update(true); err != nil {
-				ctx.JSON(http.StatusInternalServerError, gin.H{
-					"error": fmt.Sprintf("update failed: %s", err),
-				})
-				return
+				if "already up-to-date" != err {
+					ctx.JSON(http.StatusInternalServerError, gin.H{
+						"error": fmt.Sprintf("update failed: %s", err),
+					})
+					return
+				}
 			}
 		} else {
 			// load catalog(s)


### PR DESCRIPTION
Hi there,

if I update a maiden project with is already up to date, I get a confusing error message: "update failed: already up to date". This leaves me thinking that the update process somehow went wrong (and no new version could be retrieved).
This PR detect exactly this case and proceeds with a successful update message (and thus hopefully reduces confusion for the user).

Best regards,
tpltnt

