### PR TITLE
eval evaluates current line if nothing selected + Ctl-Enter evals

### DIFF
--- a/web/src/editor.js
+++ b/web/src/editor.js
@@ -155,8 +155,11 @@ class Editor extends Component {
   }
 
   handleEval() {
-    const code = this.editor.getSelectedText().replace(/--.*\n/g,';').replace(/\n/g,';')
-    this.props.selectionEval(code);
+    var code = this.editor.getSelectedText();
+    if (code==="") {
+      code = this.editor.session.getLine(this.editor.getSelectionRange().start.row);
+    }
+    this.props.selectionEval(code.replace(/--.*\n/g,';').replace(/\n/g,';'));
   }
 
   render() {

--- a/web/src/services.js
+++ b/web/src/services.js
@@ -123,6 +123,7 @@ keyService.bindings = [
   new KeyBinding(new KeyStroke(Modifier.CMD, 'b'), 'toggle sidebar'),
   new KeyBinding(new KeyStroke(Modifier.CMD, ';'), 'show config'),
   new KeyBinding(new KeyStroke(Modifier.CMD, '8'), 'eval'),
+  new KeyBinding(new KeyStroke(Modifier.CMD, 'enter'), 'eval'),
 ];
 
 class TextMode extends EditorMode {


### PR DESCRIPTION
this PR pulls in an idea from SuperCollider: that Ctl+Enter will evaluate the current line or the current selection. to do this I made two changes:

- Ctl+Enter is valid key-binding to do a `eval`
- the `eval` will evaluate the current line if nothing is selected

why? this PR makes maiden easier to use as a live coding environment. I've started using [maiden as a live-coding environment](https://github.com/schollz/nornsdeck) but currently I'm doing this with vim with special bindings+utilities to send lines to maiden. however, I thought if I were to make this available to other people it would be great to have the "send current line" functionality available in maiden, which is much easier to use than vim. 

of course, feel free to completely ignore this PR for any reason :)