### PR TITLE
Play audio files in maiden

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "parse-filepath": "^1.0.2",
     "react": "^16.8",
     "react-ace": "^9.2.1",
+    "react-audio-player": "^0.17.0",
     "react-dom": "^16.8",
     "react-linkify": "^0.2.2",
     "react-modal": "^3.8",
@@ -38,6 +39,12 @@
   },
   "proxy": "http://localhost:5000",
   "devDependencies": {
+    "@babel/core": "^7.4.5",
+    "@storybook/addon-actions": "^5.0.11",
+    "@storybook/addon-links": "^5.0.11",
+    "@storybook/addons": "^5.0.11",
+    "@storybook/react": "^5.0.11",
+    "babel-loader": "^8.0.6",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-prettier": "^2.10.0",
@@ -46,12 +53,6 @@
     "eslint-plugin-prettier": "^2.7.0",
     "eslint-plugin-react": "^7.12.0",
     "prettier": "1.12.1",
-    "redux-devtools": "^3.4.1",
-    "@storybook/react": "^5.0.11",
-    "@storybook/addon-actions": "^5.0.11",
-    "@storybook/addon-links": "^5.0.11",
-    "@storybook/addons": "^5.0.11",
-    "@babel/core": "^7.4.5",
-    "babel-loader": "^8.0.6"
+    "redux-devtools": "^3.4.1"
   }
 }

--- a/web/src/edit-activity.css
+++ b/web/src/edit-activity.css
@@ -17,6 +17,12 @@
     background-color: #F9F9F9;
 }
 
+.listener-pane {
+  display: flex;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+}
 
 .repl-pane {
     display: flex;

--- a/web/src/edit-activity.js
+++ b/web/src/edit-activity.js
@@ -217,6 +217,7 @@ class EditActivity extends Component {
   }
 
   render() {
+    console.log("hello");
     const activeBuffer = this.props.activeBuffer;
     const buffer = this.getActiveBuffer();
 
@@ -282,50 +283,7 @@ class EditActivity extends Component {
       height: this.props.height,
     }
 
-    if (canListen) {
-      return (
-        <SplitPane
-          split="vertical"
-          style={sidebarSplitStyle}
-          {...this.sidebarSplitSizing()}
-          onChange={this.handleSidebarSplitChange}
-          onDragFinished={this.handleSidebarSplitDragFinish}
-          paneClassName="editor-pane-common"
-        >
-          <Explorer
-            className="explorer-container"
-            hidden={this.props.ui.sidebarHidden}
-            style={explorerStyle}
-            data={this.props.explorerData}
-            bufferSelect={this.props.bufferSelect}
-            directoryRead={this.props.directoryRead}
-            directoryCreate={this.props.explorerDirectoryCreate}
-            scriptCreate={this.props.explorerScriptNew}
-            scriptDuplicate={this.props.explorerScriptDuplicate}
-            resourceDelete={this.props.explorerResourceDelete}
-            resourceRename={this.handleResourceRename}
-            collapsedCategories={this.props.collapsedCategories}
-            explorerToggleCategory={this.props.explorerToggleCategory}
-            explorerToggleNode={this.props.explorerToggleNode}
-            explorerActiveNode={this.props.explorerActiveNode}
-            activeBuffer={activeBuffer}
-            activeNode={this.props.activeNode}
-            showModal={this.props.showModal}
-            hideModal={this.props.hideModal}
-          />
-          <SplitPane
-            split="horizontal"
-            primary="second"
-            {...this.replSplitSizing()}
-            onChange={this.handleReplSplitChange}
-            onDragFinished={this.handleReplSplitDragFinish}
-          >
-            {listener}
-            <ReplActivity {...this.replSize()} />
-          </SplitPane>
-        </SplitPane>
-      );
-    }
+    const element = canListen ? listener : editor;
 
     return (
       <SplitPane
@@ -364,7 +322,7 @@ class EditActivity extends Component {
           onChange={this.handleReplSplitChange}
           onDragFinished={this.handleReplSplitDragFinish}
         >
-          {editor}
+          {element}
           <ReplActivity {...this.replSize()} />
         </SplitPane>
       </SplitPane>

--- a/web/src/edit-activity.js
+++ b/web/src/edit-activity.js
@@ -217,7 +217,6 @@ class EditActivity extends Component {
   }
 
   render() {
-    console.log("hello");
     const activeBuffer = this.props.activeBuffer;
     const buffer = this.getActiveBuffer();
 

--- a/web/src/model/edit-helpers.js
+++ b/web/src/model/edit-helpers.js
@@ -3,3 +3,7 @@ export const bufferIsEditable = (buffer) => {
   return contentType.includes('text') || contentType.includes('application/json');
 };
 
+export const bufferIsAudio = (buffer) => {
+  const contentType = buffer.get('contentType');
+  return contentType.includes('audio');
+}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -10991,6 +10991,13 @@ react-ace@^9.2.1:
     lodash.isequal "^4.5.0"
     prop-types "^15.7.2"
 
+react-audio-player@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/react-audio-player/-/react-audio-player-0.17.0.tgz#4be7b1952512801f36ba0865a9c98f7b108f991e"
+  integrity sha512-aCZgusPxA9HK7rLZcTdhTbBH9l6do9vn3NorgoDZRxRxJlOy9uZWzPaKjd7QdcuP2vXpxGA/61JMnnOEY7NXeA==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-clientside-effect@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.0.tgz#db823695f75e9616a5e4dd6d908e5ea627fb2516"


### PR DESCRIPTION
This leverages `react-audio-player` and some very basic logic to play a file with an `audio/*` MIME type instead of showing the editor. This would address #83, I believe (in its original intent, not the upload/download idea).

However, it takes a moment to load the file, and during that time still displays the editor. That's a little confusing, but I know nothing about React so I'm not sure where to fix that. If somebody could give me a pointer, I'd be happy to add that to this PR.