### PR TITLE
Add version metadata during build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 default: build
 
+GO_LDFLAGS += -X github.com/monome/maiden/cmd.version=$(shell git describe --tags)
+GO_LDFLAGS += -X github.com/monome/maiden/cmd.compileTime=$(shell date -u +%Y-%m-%dT%H:%M)
+export GO_LDFLAGS
+
 build:
-	go build
+	go build -ldflags="${GO_LDFLAGS}"
 
 release:
 	tool/release.sh

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -71,8 +71,7 @@ func serverRun() {
 	dataDir = os.ExpandEnv(viper.GetString("dust.path"))
 	docDir = os.ExpandEnv(viper.GetString("doc.path"))
 
-	// FIXME: pull in git version
-	logger.Infof("maiden (%s)", version)
+	logger.Infof("maiden: %s", Version())
 	logger.Infof("  http: %s", httpLocation)
 	logger.Infof("   app: %s", appDir)
 	logger.Infof("  data: %s", dataDir)
@@ -103,7 +102,7 @@ func serverRun() {
 	api := r.Group(apiRoot)
 
 	api.GET("", func(ctx *gin.Context) {
-		ctx.JSON(http.StatusOK, apiInfo{"maiden", version})
+		ctx.JSON(http.StatusOK, apiInfo{"maiden", Version()})
 	})
 
 	// dust api

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.2"
+var (
+	version string = "development"
+	compileTime string
+)
+
+// Version constructs the formatted version string.
+func Version() string {
+	if compileTime != "" {
+		return fmt.Sprintf("%s / %s", version, compileTime)
+	}
+	return version
+}
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
@@ -15,7 +26,7 @@ var versionCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ConfigureLogger()
 		LoadConfiguration()
-		fmt.Println(version)
+		fmt.Println(Version())
 	},
 }
 

--- a/tool/release.sh
+++ b/tool/release.sh
@@ -11,7 +11,7 @@ mkdir -pv $REL_DIR
 # maiden
 echo -e "building maiden"
 echo "====================="
-cmd='GOOS=linux GOARCH=arm go build -o $REL_DIR/maiden'
+cmd="GOOS=linux GOARCH=arm go build -ldflags='${GO_LDFLAGS}' -o $REL_DIR/maiden"
 echo $cmd
 eval $cmd
 # for compatibility with old systemd unit setup


### PR DESCRIPTION
The version reported by `./maiden version` is currently incorrect on a clean build. This PR adjusts the build to inject the current tag / build timestamp into the binary.

Before I committed these changes there was a top-level tag and the new version looks like this:
```
~$ make && ./maiden version
go build -ldflags="-X github.com/monome/maiden/cmd.version=v1.1.3 -X github.com/monome/maiden/cmd.compileTime=2021-09-10T13:25"

v1.1.3 / 2021-09-10T13:25

~$ go build && ./maiden version

development
```

After my commit, there is no top-level tag so a hash is included:
```
~$ make && ./maiden version
go build -ldflags="-X github.com/monome/maiden/cmd.version=v1.1.3-1-gbf56356 -X github.com/monome/maiden/cmd.compileTime=2021-09-10T13:27"

v1.1.3-1-gbf56356 / 2021-09-10T13:27
``` 