### PR TITLE
fix: close prior REPL websocket on reconnect to stop duplicated output

### DIFF
--- a/web/src/model/repl-actions.js
+++ b/web/src/model/repl-actions.js
@@ -87,7 +87,24 @@ export const replEndpoints = cb => dispatch => {
   });
 };
 
-export const replConnect = (component, endpoint, retryCount) => dispatch => {
+export const replDisconnect = (component) => (dispatch, getState) => {
+  const existing = getState().repl.connections.get(component);
+  if (!existing) return;
+  const socket = existing.get('socket');
+  if (socket) {
+    // detach handlers so that an orphaned connection's late onclose doesn't
+    // clobber the new socket's state
+    socket.onopen = null;
+    socket.onerror = null;
+    socket.onclose = null;
+    socket.onmessage = null;
+    socket.close();
+  }
+  dispatch(replConnectClose(component));
+};
+
+export const replConnect = (component, endpoint, retryCount) => (dispatch, getState) => {
+  dispatch(replDisconnect(component));
   dispatch(replConnectDial(component, endpoint));
   const socket = new WebSocket(endpoint, ['bus.sp.nanomsg.org']);
   socket.onopen = () => {


### PR DESCRIPTION
_what_

`replConnect` was opening a new WebSocket without closing prior connections. Each surviving socket kept receiving stdout and REPL output appeared duplicated (2x after one restart, 3x after two, etc.). This PR adds a `replDisconnect` action that closes the existing socket (if it exists) and detaches its handlers before dialing a new one. 